### PR TITLE
宏 schema 对齐 + 完成 29-32 宏表实现

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,11 +34,14 @@
 # Editor related
 .vscode/*
 .zed/*
+/build/
 build/*
+compile_commands.json
 .clangd
 .aider*
 
 # Project related
+*.db
 ast.db*
 *-db/
 
@@ -50,3 +53,4 @@ ast.db*
 
 # test
 tests/*.local/
+/arbor_notes/

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ build/*
 compile_commands.json
 .clangd
 .aider*
+.cache/
 
 # Project related
 *.db

--- a/docs/datatable-list.txt
+++ b/docs/datatable-list.txt
@@ -26,10 +26,10 @@ DONE    23. folders
    26. inmacroexpansion
    27. affectedbymacroexpansion
 DONE    28. macroinvocations
-   29. macroparent
-   30. macrolocationbind
-   31. macro_argument_unexpanded
-   32. macro_argument_expanded
+DONE    29. macroparent
+DONE    30. macrolocationbind
+DONE    31. macro_argument_unexpanded
+DONE    32. macro_argument_expanded
 DONE    33. functions
 DONE    34. function_entry_point
 DONE    35. function_return_type

--- a/docs/datatable-list.txt
+++ b/docs/datatable-list.txt
@@ -25,7 +25,7 @@ DONE    23. folders
    25. fileannotations
    26. inmacroexpansion
    27. affectedbymacroexpansion
-   28. macroinvocations
+DONE    28. macroinvocations
    29. macroparent
    30. macrolocationbind
    31. macro_argument_unexpanded

--- a/include/core/processor/preprocessor_processor.h
+++ b/include/core/processor/preprocessor_processor.h
@@ -10,6 +10,8 @@
 #include <clang/Lex/Preprocessor.h>
 #include <stack>
 #include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 using namespace clang;
 
@@ -73,6 +75,10 @@ private:
   // Track which branches evaluated to true/false
   std::unordered_map<int, bool> branch_evaluation_;
   std::unordered_map<std::string, int> macro_define_id_by_name_;
+  std::unordered_set<std::string> macro_argument_dedup_cache_;
+  std::unordered_set<std::string> macrolocationbind_dedup_cache_;
+  std::unordered_set<int> macroparent_child_dedup_cache_;
+  std::unordered_map<unsigned, int> macro_invocation_by_loc_key_;
 
   static constexpr int kMacroExpansionKind = 1;
   static constexpr int kOtherMacroReferenceKind = 2;
@@ -99,7 +105,19 @@ private:
   std::string getSourceText(CharSourceRange range);
 
   // Record macro invocation/reference row if matching define id is known.
-  void recordMacroInvocation(const Token &MacroNameTok, SourceLocation Loc, int kind);
+  int recordMacroInvocation(const Token &MacroNameTok, SourceLocation Loc, int kind);
+
+  // Convert tokens to a stable space-joined text representation.
+  std::string tokensToText(const Token *tokens, unsigned token_count) const;
+  std::string tokensToText(const std::vector<Token> &tokens) const;
+
+  // Prevent duplicate insertions for the same (invocation, argument_index, table).
+  bool shouldInsertMacroArgumentRow(int invocation_id, int argument_index,
+                                    bool is_expanded);
+
+  bool shouldInsertMacroLocationBindRow(int invocation_id, int location_id);
+  bool shouldInsertMacroParentRow(int child_id);
+  unsigned makeMacroLocationKey(SourceLocation loc) const;
 };
 
 #endif // _PREPROCESSOR_PROCESSOR_H_

--- a/include/core/processor/preprocessor_processor.h
+++ b/include/core/processor/preprocessor_processor.h
@@ -72,7 +72,8 @@ private:
   ////// Helper Methods //////
 
   // Process a preprocessor directive and return its ID
-  int processDirective(SourceLocation Loc, PreprocDirectKind kind);
+  int processDirective(SourceLocation Loc, PreprocDirectKind kind,
+                       const std::string &key_suffix = "");
 
   // Extract and store directive text (head and body)
   void extractDirectiveText(SourceLocation Loc, int directive_id, PreprocDirectKind kind);

--- a/include/core/processor/preprocessor_processor.h
+++ b/include/core/processor/preprocessor_processor.h
@@ -44,9 +44,13 @@ public:
 
   ////// PPCallbacks Interface - Macro Definitions //////
 
+  void MacroExpands(const Token &MacroNameTok, const MacroDefinition &MD,
+                    SourceRange Range, const MacroArgs *Args) override;
   void MacroDefined(const Token &MacroNameTok, const MacroDirective *MD) override;
   void MacroUndefined(const Token &MacroNameTok, const MacroDefinition &MD,
                       const MacroDirective *Undef) override;
+  void Defined(const Token &MacroNameTok, const MacroDefinition &MD,
+               SourceRange Range) override;
 
   ////// PPCallbacks Interface - Other Directives //////
 
@@ -68,6 +72,10 @@ private:
 
   // Track which branches evaluated to true/false
   std::unordered_map<int, bool> branch_evaluation_;
+  std::unordered_map<std::string, int> macro_define_id_by_name_;
+
+  static constexpr int kMacroExpansionKind = 1;
+  static constexpr int kOtherMacroReferenceKind = 2;
 
   ////// Helper Methods //////
 
@@ -89,6 +97,9 @@ private:
 
   // Get full source text for a source range
   std::string getSourceText(CharSourceRange range);
+
+  // Record macro invocation/reference row if matching define id is known.
+  void recordMacroInvocation(const Token &MacroNameTok, SourceLocation Loc, int kind);
 };
 
 #endif // _PREPROCESSOR_PROCESSOR_H_

--- a/include/db/table_defs/preprocessor.h
+++ b/include/db/table_defs/preprocessor.h
@@ -53,13 +53,13 @@ inline auto includes() {
       make_column("included", &DbModel::Includes::included));
 }
 
-inline auto macro_defs() {
+inline auto macroinvocations() {
   return make_table(
-      "macro_defs",
-      make_column("id", &DbModel::MacroDef::id, primary_key()),
-      make_column("name", &DbModel::MacroDef::name),
-      make_column("body", &DbModel::MacroDef::body),
-      make_column("location", &DbModel::MacroDef::location));
+      "macroinvocations",
+      make_column("id", &DbModel::MacroInvocation::id, primary_key()),
+      make_column("macro_id", &DbModel::MacroInvocation::macro_id),
+      make_column("location", &DbModel::MacroInvocation::location),
+      make_column("kind", &DbModel::MacroInvocation::kind));
 }
 
 // clang-format on

--- a/include/db/table_defs/preprocessor.h
+++ b/include/db/table_defs/preprocessor.h
@@ -62,6 +62,42 @@ inline auto macroinvocations() {
       make_column("kind", &DbModel::MacroInvocation::kind));
 }
 
+inline auto macroparent() {
+  return make_table(
+      "macroparent",
+      make_column("id", &DbModel::MacroParent::id, primary_key()),
+      make_column("parent_id", &DbModel::MacroParent::parent_id));
+}
+
+inline auto macrolocationbind() {
+  return make_table(
+      "macrolocationbind",
+      make_column("id", &DbModel::MacroLocationBind::id),
+      make_column("location", &DbModel::MacroLocationBind::location));
+}
+
+inline auto macro_argument_unexpanded() {
+  return make_table(
+      "macro_argument_unexpanded",
+      make_column("invocation", &DbModel::MacroArgumentUnexpanded::invocation),
+      make_column("argument_index",
+                  &DbModel::MacroArgumentUnexpanded::argument_index),
+      make_column("text", &DbModel::MacroArgumentUnexpanded::text),
+      primary_key(&DbModel::MacroArgumentUnexpanded::invocation,
+                  &DbModel::MacroArgumentUnexpanded::argument_index));
+}
+
+inline auto macro_argument_expanded() {
+  return make_table(
+      "macro_argument_expanded",
+      make_column("invocation", &DbModel::MacroArgumentExpanded::invocation),
+      make_column("argument_index",
+                  &DbModel::MacroArgumentExpanded::argument_index),
+      make_column("text", &DbModel::MacroArgumentExpanded::text),
+      primary_key(&DbModel::MacroArgumentExpanded::invocation,
+                  &DbModel::MacroArgumentExpanded::argument_index));
+}
+
 // clang-format on
 
 } // namespace PreprocessorTableFn

--- a/include/db/table_defs/preprocessor.h
+++ b/include/db/table_defs/preprocessor.h
@@ -53,6 +53,15 @@ inline auto includes() {
       make_column("included", &DbModel::Includes::included));
 }
 
+inline auto macro_defs() {
+  return make_table(
+      "macro_defs",
+      make_column("id", &DbModel::MacroDef::id, primary_key()),
+      make_column("name", &DbModel::MacroDef::name),
+      make_column("body", &DbModel::MacroDef::body),
+      make_column("location", &DbModel::MacroDef::location));
+}
+
 // clang-format on
 
 } // namespace PreprocessorTableFn

--- a/include/db/table_init.h
+++ b/include/db/table_init.h
@@ -138,7 +138,7 @@ inline auto initStorage(const std::string &path) {
       PreprocessorTableFn::preprocfalse(),
       PreprocessorTableFn::preproctext(),
       PreprocessorTableFn::includes(),
-      PreprocessorTableFn::macro_defs()
+      PreprocessorTableFn::macroinvocations()
     );
   // clang-format on
 }

--- a/include/db/table_init.h
+++ b/include/db/table_init.h
@@ -137,7 +137,8 @@ inline auto initStorage(const std::string &path) {
       PreprocessorTableFn::preproctrue(),
       PreprocessorTableFn::preprocfalse(),
       PreprocessorTableFn::preproctext(),
-      PreprocessorTableFn::includes()
+      PreprocessorTableFn::includes(),
+      PreprocessorTableFn::macro_defs()
     );
   // clang-format on
 }

--- a/include/db/table_init.h
+++ b/include/db/table_init.h
@@ -138,7 +138,11 @@ inline auto initStorage(const std::string &path) {
       PreprocessorTableFn::preprocfalse(),
       PreprocessorTableFn::preproctext(),
       PreprocessorTableFn::includes(),
-      PreprocessorTableFn::macroinvocations()
+      PreprocessorTableFn::macroinvocations(),
+      PreprocessorTableFn::macroparent(),
+      PreprocessorTableFn::macrolocationbind(),
+      PreprocessorTableFn::macro_argument_unexpanded(),
+      PreprocessorTableFn::macro_argument_expanded()
     );
   // clang-format on
 }

--- a/include/model/db/preprocessor.h
+++ b/include/model/db/preprocessor.h
@@ -64,6 +64,28 @@ struct MacroInvocation {
   int kind;
 };
 
+struct MacroParent {
+  int id;
+  int parent_id;
+};
+
+struct MacroLocationBind {
+  int id;
+  int location;
+};
+
+struct MacroArgumentUnexpanded {
+  int invocation;
+  int argument_index;
+  std::string text;
+};
+
+struct MacroArgumentExpanded {
+  int invocation;
+  int argument_index;
+  std::string text;
+};
+
 } // namespace DbModel
 
 #endif // _MODEL_PREPROCESSOR_H_

--- a/include/model/db/preprocessor.h
+++ b/include/model/db/preprocessor.h
@@ -57,11 +57,11 @@ struct Includes {
   int included;
 };
 
-struct MacroDef {
+struct MacroInvocation {
   int id;
-  std::string name;
-  std::string body;
+  int macro_id;
   int location;
+  int kind;
 };
 
 } // namespace DbModel

--- a/include/model/db/preprocessor.h
+++ b/include/model/db/preprocessor.h
@@ -57,6 +57,13 @@ struct Includes {
   int included;
 };
 
+struct MacroDef {
+  int id;
+  std::string name;
+  std::string body;
+  int location;
+};
+
 } // namespace DbModel
 
 #endif // _MODEL_PREPROCESSOR_H_

--- a/include/util/key_generator/preprocessor.h
+++ b/include/util/key_generator/preprocessor.h
@@ -3,8 +3,6 @@
 
 #include "db/cache_repository.h"
 #include "model/db/preprocessor.h"
-#include <clang/Basic/SourceLocation.h>
-#include <clang/Lex/Preprocessor.h>
 #include <string>
 
 #define SEARCH_PREPROC_CACHE(key)                                             \
@@ -24,7 +22,8 @@ namespace KeyGen {
 namespace Preprocessor {
 
 // Generate unique key for preprocessor directive based on source location
-KeyType makeKey(clang::SourceLocation Loc, clang::Preprocessor &PP);
+KeyType makeKey(const std::string &filename, unsigned line, unsigned column,
+                int directive_kind, const std::string &extra_tag = "");
 
 } // namespace Preprocessor
 

--- a/scripts/check_db.sh
+++ b/scripts/check_db.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DB="${1:-tests/ast.db}"
+shift || true
+
+LIKE=""
+COUNT_LIST=""
+SAMPLES=()
+FILE_NAME=""
+
+usage() {
+  cat <<EOF
+Usage:
+  $0 [db] [options]
+
+Options:
+  --like PATTERN             List tables matching pattern (e.g. preproc%).
+  --count t1,t2,t3           Count rows for these tables (if table exists).
+  --sample table:N           Print first N rows of table (repeatable).
+  --file FILENAME            Focus: show preproc rows belonging to a file name in files.name
+  -h, --help                 Show help.
+
+Examples:
+  $0 tests/ast.db
+  $0 tests/ast.db --like preproc%
+  $0 tests/ast.db --count functions,variable,types --sample functions:5
+  $0 tests/ast.db --file macro_basic.cc
+EOF
+}
+
+# ---------------- parse args ----------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --like) LIKE="${2:-}"; shift 2;;
+    --count) COUNT_LIST="${2:-}"; shift 2;;
+    --sample) SAMPLES+=("${2:-}"); shift 2;;
+    --file) FILE_NAME="${2:-}"; shift 2;;
+    -h|--help) usage; exit 0;;
+    *) echo "[!] Unknown arg: $1"; usage; exit 1;;
+  esac
+done
+
+if [[ ! -f "$DB" ]]; then
+  echo "[!] DB not found: $DB"
+  exit 1
+fi
+
+echo "[*] DB: $DB"
+
+# helper: run single SQL and print
+run_sql() {
+  local sql="$1"
+  sqlite3 "$DB" <<SQL
+.headers on
+.mode column
+${sql}
+SQL
+}
+
+# helper: check table exists (exit code 0/1)
+table_exists() {
+  local t="$1"
+  sqlite3 "$DB" "SELECT 1 FROM sqlite_master WHERE type='table' AND name='$t' LIMIT 1;" | grep -q 1
+}
+
+echo
+echo "== Basic summary =="
+run_sql "
+SELECT 'tables_total' AS k, COUNT(*) AS v FROM sqlite_master WHERE type='table';
+SELECT name FROM sqlite_master WHERE type='table' ORDER BY name LIMIT 40;
+"
+
+# ---- default key tables we care about ----
+DEFAULT_KEYS=(files locations functions variable types exprs stmts preprocdirects preproctext)
+
+echo
+echo "== Key table counts (only if exists) =="
+for t in "${DEFAULT_KEYS[@]}"; do
+  if table_exists "$t"; then
+    n=$(sqlite3 "$DB" "SELECT COUNT(*) FROM \"$t\";")
+    printf "%-20s %s\n" "$t" "$n"
+  else
+    printf "%-20s %s\n" "$t" "(missing)"
+  fi
+done
+
+# ---- list tables by pattern ----
+if [[ -n "$LIKE" ]]; then
+  echo
+  echo "== Tables LIKE '$LIKE' =="
+  run_sql "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE '$LIKE' ORDER BY name;"
+fi
+
+# ---- count specific list ----
+if [[ -n "$COUNT_LIST" ]]; then
+  echo
+  echo "== Counts (requested) =="
+  IFS=',' read -r -a arr <<<"$COUNT_LIST"
+  for t in "${arr[@]}"; do
+    t="${t// /}"
+    [[ -z "$t" ]] && continue
+    if table_exists "$t"; then
+      n=$(sqlite3 "$DB" "SELECT COUNT(*) FROM \"$t\";")
+      printf "%-20s %s\n" "$t" "$n"
+    else
+      printf "%-20s %s\n" "$t" "(missing)"
+    fi
+  done
+fi
+
+# ---- sample rows ----
+if [[ ${#SAMPLES[@]} -gt 0 ]]; then
+  echo
+  echo "== Samples =="
+  for item in "${SAMPLES[@]}"; do
+    tbl="${item%%:*}"
+    lim="${item##*:}"
+    if [[ "$tbl" == "$lim" ]]; then lim="10"; fi
+    if table_exists "$tbl"; then
+      echo "-- $tbl (LIMIT $lim) --"
+      run_sql "SELECT * FROM \"$tbl\" LIMIT $lim;"
+    else
+      echo "-- $tbl missing --"
+    fi
+  done
+fi
+
+# ---- focus by file ----
+if [[ -n "$FILE_NAME" ]]; then
+  echo
+  echo "== Focus: file '$FILE_NAME' =="
+  if ! table_exists "files"; then
+    echo "[!] files table missing"
+    exit 1
+  fi
+
+  file_id=$(sqlite3 "$DB" "SELECT id FROM files WHERE name='$FILE_NAME' LIMIT 1;")
+  if [[ -z "$file_id" ]]; then
+    echo "[!] file not found in files.name: $FILE_NAME"
+    echo "    Try: sqlite3 $DB \"SELECT * FROM files LIMIT 20;\""
+    exit 1
+  fi
+  echo "[*] file_id = $file_id"
+
+  # need locations + preprocdirects
+  if table_exists "locations" && table_exists "preprocdirects"; then
+    echo
+    echo "-- preprocdirects rows for this file (via location->locations.file) --"
+    # NOTE: this assumes locations has column 'file'. If not, you’ll see error; then we adjust.
+    run_sql "
+SELECT p.id, p.kind, p.location
+FROM preprocdirects p
+JOIN locations l ON l.id = p.location
+WHERE l.file = $file_id
+LIMIT 50;
+"
+  else
+    echo "[!] need locations + preprocdirects tables"
+  fi
+
+  # join preproctext if possible (common pattern: preprocdirects.id == preproctext.id)
+  if table_exists "preproctext" && table_exists "locations" && table_exists "preprocdirects"; then
+    echo
+    echo "-- preproc text for this file (join p.id=t.id) --"
+    run_sql "
+SELECT l.line, l.column, p.kind, t.head, t.body
+FROM preprocdirects p
+JOIN preproctext t ON t.id = p.id
+JOIN locations l ON l.id = p.location
+WHERE l.file = $file_id
+LIMIT 50;
+"
+  fi
+fi
+
+echo
+echo "[+] Done."

--- a/scripts/check_db2.sh
+++ b/scripts/check_db2.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DB="${1:-tests/ast.db}"
+
+echo "[*] DB: $DB"
+sqlite3 "$DB" <<'SQL'
+.headers on
+.mode column
+
+-- 1) 看主要表是否存在
+SELECT name FROM sqlite_master WHERE type='table' ORDER BY name LIMIT 30;
+
+-- 2) 关键表计数
+SELECT COUNT(*) AS functions_cnt FROM functions;
+SELECT COUNT(*) AS vars_cnt      FROM variable;
+SELECT COUNT(*) AS types_cnt     FROM types;
+SELECT COUNT(*) AS stmts_cnt     FROM stmt;
+SELECT COUNT(*) AS exprs_cnt     FROM expr;
+
+-- 3) 抽样看看内容（避免“表有但全空/字段异常”）
+SELECT * FROM functions LIMIT 5;
+SELECT * FROM variable  LIMIT 5;
+SQL
+
+echo "[+] Done."

--- a/src/core/processor/preprocessor_processor.cc
+++ b/src/core/processor/preprocessor_processor.cc
@@ -24,6 +24,8 @@ PreprocessorProcessor::PreprocessorProcessor(ASTContext *ast_context,
 void PreprocessorProcessor::Ifndef(SourceLocation Loc,
                                    const Token &MacroNameTok,
                                    const MacroDefinition &MD) {
+  recordMacroInvocation(MacroNameTok, Loc, kOtherMacroReferenceKind);
+
   int dir_id = processDirective(Loc, PreprocDirectKind::IFNDEF);
   branch_stack_.push({dir_id, PreprocDirectKind::IFNDEF, Loc});
 
@@ -36,6 +38,8 @@ void PreprocessorProcessor::Ifndef(SourceLocation Loc,
 
 void PreprocessorProcessor::Ifdef(SourceLocation Loc, const Token &MacroNameTok,
                                   const MacroDefinition &MD) {
+  recordMacroInvocation(MacroNameTok, Loc, kOtherMacroReferenceKind);
+
   int dir_id = processDirective(Loc, PreprocDirectKind::IFDEF);
   branch_stack_.push({dir_id, PreprocDirectKind::IFDEF, Loc});
 
@@ -153,6 +157,15 @@ void PreprocessorProcessor::InclusionDirective(
 // Macro Definition Callbacks
 //////////////////////////////////////////////////////////////////////////////
 
+void PreprocessorProcessor::MacroExpands(const Token &MacroNameTok,
+                                         const MacroDefinition &MD,
+                                         SourceRange Range,
+                                         const MacroArgs *Args) {
+  (void)MD;
+  (void)Args;
+  recordMacroInvocation(MacroNameTok, Range.getBegin(), kMacroExpansionKind);
+}
+
 void PreprocessorProcessor::MacroDefined(const Token &MacroNameTok,
                                          const MacroDirective *MD) {
   const auto *identifier = MacroNameTok.getIdentifierInfo();
@@ -169,6 +182,7 @@ void PreprocessorProcessor::MacroDefined(const Token &MacroNameTok,
 
   const std::string macro_name = identifier->getName().str();
   int dir_id = processDirective(Loc, PreprocDirectKind::DEFINE, macro_name);
+  macro_define_id_by_name_[macro_name] = dir_id;
 
   // Build macro body directly from MacroInfo replacement tokens.
   std::string macro_body;
@@ -191,20 +205,32 @@ void PreprocessorProcessor::MacroDefined(const Token &MacroNameTok,
 
   Preproctext text = {dir_id, macro_name, macro_body};
   STG.insertClassObj(text);
-
-  // Write a dedicated, cleaner macro definition record for user macros.
-  LocIdPair *loc_pair = PROC_DEFT(Loc, Loc, ast_context_);
-  MacroDef macro_def = {dir_id, macro_name, macro_body, loc_pair->spec_id};
-  STG.insertClassObj(macro_def);
 }
 
 void PreprocessorProcessor::MacroUndefined(const Token &MacroNameTok,
                                            const MacroDefinition &MD,
                                            const MacroDirective *Undef) {
+  (void)MD;
+  (void)Undef;
+
+  recordMacroInvocation(MacroNameTok, MacroNameTok.getLocation(),
+                        kOtherMacroReferenceKind);
+
+  if (const auto *identifier = MacroNameTok.getIdentifierInfo()) {
+    macro_define_id_by_name_.erase(identifier->getName().str());
+  }
+
   // Keep UNDEF behavior unchanged: record directive and raw text only.
   SourceLocation Loc = MacroNameTok.getLocation();
   int dir_id = processDirective(Loc, PreprocDirectKind::UNDEF);
   extractDirectiveText(Loc, dir_id, PreprocDirectKind::UNDEF);
+}
+
+void PreprocessorProcessor::Defined(const Token &MacroNameTok,
+                                    const MacroDefinition &MD,
+                                    SourceRange Range) {
+  (void)MD;
+  recordMacroInvocation(MacroNameTok, Range.getBegin(), kOtherMacroReferenceKind);
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -370,4 +396,28 @@ int PreprocessorProcessor::resolveIncludeFile(const std::string &filename) {
 std::string PreprocessorProcessor::getSourceText(CharSourceRange range) {
   const SourceManager &SM = ast_context_->getSourceManager();
   return Lexer::getSourceText(range, SM, LangOptions()).str();
+}
+
+void PreprocessorProcessor::recordMacroInvocation(const Token &MacroNameTok,
+                                                  SourceLocation Loc, int kind) {
+  const auto *identifier = MacroNameTok.getIdentifierInfo();
+  if (!identifier) {
+    return;
+  }
+
+  auto it = macro_define_id_by_name_.find(identifier->getName().str());
+  if (it == macro_define_id_by_name_.end()) {
+    return;
+  }
+
+  const SourceManager &SM = ast_context_->getSourceManager();
+  SourceLocation file_loc = SM.getFileLoc(SM.getSpellingLoc(Loc));
+  if (!SM.isWrittenInMainFile(file_loc)) {
+    return;
+  }
+
+  LocIdPair *loc_pair = PROC_DEFT(file_loc, file_loc, ast_context_);
+  int invocation_id = GENID(MacroInvocation);
+  MacroInvocation invocation = {invocation_id, it->second, loc_pair->spec_id, kind};
+  STG.insertClassObj(invocation);
 }

--- a/src/core/processor/preprocessor_processor.cc
+++ b/src/core/processor/preprocessor_processor.cc
@@ -21,7 +21,8 @@ PreprocessorProcessor::PreprocessorProcessor(ASTContext *ast_context,
 // Conditional Compilation Callbacks
 //////////////////////////////////////////////////////////////////////////////
 
-void PreprocessorProcessor::Ifndef(SourceLocation Loc, const Token &MacroNameTok,
+void PreprocessorProcessor::Ifndef(SourceLocation Loc,
+                                   const Token &MacroNameTok,
                                    const MacroDefinition &MD) {
   int dir_id = processDirective(Loc, PreprocDirectKind::IFNDEF);
   branch_stack_.push({dir_id, PreprocDirectKind::IFNDEF, Loc});
@@ -58,8 +59,8 @@ void PreprocessorProcessor::If(SourceLocation Loc, SourceRange ConditionRange,
 }
 
 void PreprocessorProcessor::Elif(SourceLocation Loc, SourceRange ConditionRange,
-                                ConditionValueKind ConditionValue,
-                                SourceLocation IfLoc) {
+                                 ConditionValueKind ConditionValue,
+                                 SourceLocation IfLoc) {
   int dir_id = processDirective(Loc, PreprocDirectKind::ELIF);
 
   // Pop the previous branch (if/elif) and record pair
@@ -114,27 +115,25 @@ void PreprocessorProcessor::Endif(SourceLocation Loc, SourceLocation IfLoc) {
 
 void PreprocessorProcessor::InclusionDirective(
     SourceLocation HashLoc, const Token &IncludeTok, StringRef FileName,
-    bool IsAngled, CharSourceRange FilenameRange,
-    OptionalFileEntryRef File,
-    StringRef SearchPath, StringRef RelativePath,
-    const Module *SuggestedModule, bool ModuleImported,
-    SrcMgr::CharacteristicKind FileType) {
+    bool IsAngled, CharSourceRange FilenameRange, OptionalFileEntryRef File,
+    StringRef SearchPath, StringRef RelativePath, const Module *SuggestedModule,
+    bool ModuleImported, SrcMgr::CharacteristicKind FileType) {
 
   // Determine include kind
   PreprocDirectKind kind;
   switch (IncludeTok.getIdentifierInfo()->getPPKeywordID()) {
-    case tok::pp_include:
-      kind = PreprocDirectKind::PLAIN_INCLUDE;
-      break;
-    case tok::pp_import:
-      kind = PreprocDirectKind::OBJC_IMPORT;
-      break;
-    case tok::pp_include_next:
-      kind = PreprocDirectKind::INCLUDE_NEXT;
-      break;
-    default:
-      kind = PreprocDirectKind::PLAIN_INCLUDE;
-      break;
+  case tok::pp_include:
+    kind = PreprocDirectKind::PLAIN_INCLUDE;
+    break;
+  case tok::pp_import:
+    kind = PreprocDirectKind::OBJC_IMPORT;
+    break;
+  case tok::pp_include_next:
+    kind = PreprocDirectKind::INCLUDE_NEXT;
+    break;
+  default:
+    kind = PreprocDirectKind::PLAIN_INCLUDE;
+    break;
   }
 
   int dir_id = processDirective(HashLoc, kind);
@@ -155,15 +154,54 @@ void PreprocessorProcessor::InclusionDirective(
 //////////////////////////////////////////////////////////////////////////////
 
 void PreprocessorProcessor::MacroDefined(const Token &MacroNameTok,
-                                        const MacroDirective *MD) {
-  SourceLocation Loc = MacroNameTok.getLocation();
-  int dir_id = processDirective(Loc, PreprocDirectKind::DEFINE);
-  extractDirectiveText(Loc, dir_id, PreprocDirectKind::DEFINE);
+                                         const MacroDirective *MD) {
+  const auto *identifier = MacroNameTok.getIdentifierInfo();
+  if (!identifier)
+    return;
+
+  const SourceManager &SM = ast_context_->getSourceManager();
+  SourceLocation Loc =
+      SM.getFileLoc(SM.getSpellingLoc(MacroNameTok.getLocation()));
+
+  // Only record user macros from the main source file.
+  if (!SM.isWrittenInMainFile(Loc))
+    return;
+
+  const std::string macro_name = identifier->getName().str();
+  int dir_id = processDirective(Loc, PreprocDirectKind::DEFINE, macro_name);
+
+  // Build macro body directly from MacroInfo replacement tokens.
+  std::string macro_body;
+  if (MD) {
+    const MacroInfo *MI = MD->getMacroInfo();
+    if (MI) {
+      bool first = true;
+      for (const Token &Tok : MI->tokens()) {
+        bool invalid = false;
+        std::string spelling = preprocessor_->getSpelling(Tok, &invalid);
+        if (invalid || spelling.empty())
+          continue;
+        if (!first)
+          macro_body += " ";
+        macro_body += spelling;
+        first = false;
+      }
+    }
+  }
+
+  Preproctext text = {dir_id, macro_name, macro_body};
+  STG.insertClassObj(text);
+
+  // Write a dedicated, cleaner macro definition record for user macros.
+  LocIdPair *loc_pair = PROC_DEFT(Loc, Loc, ast_context_);
+  MacroDef macro_def = {dir_id, macro_name, macro_body, loc_pair->spec_id};
+  STG.insertClassObj(macro_def);
 }
 
 void PreprocessorProcessor::MacroUndefined(const Token &MacroNameTok,
-                                          const MacroDefinition &MD,
-                                          const MacroDirective *Undef) {
+                                           const MacroDefinition &MD,
+                                           const MacroDirective *Undef) {
+  // Keep UNDEF behavior unchanged: record directive and raw text only.
   SourceLocation Loc = MacroNameTok.getLocation();
   int dir_id = processDirective(Loc, PreprocDirectKind::UNDEF);
   extractDirectiveText(Loc, dir_id, PreprocDirectKind::UNDEF);
@@ -174,22 +212,24 @@ void PreprocessorProcessor::MacroUndefined(const Token &MacroNameTok,
 //////////////////////////////////////////////////////////////////////////////
 
 void PreprocessorProcessor::PragmaDirective(SourceLocation Loc,
-                                           PragmaIntroducerKind Introducer) {
+                                            PragmaIntroducerKind Introducer) {
   int dir_id = processDirective(Loc, PreprocDirectKind::PRAGMA);
   extractDirectiveText(Loc, dir_id, PreprocDirectKind::PRAGMA);
 }
 
-void PreprocessorProcessor::PragmaMessage(SourceLocation Loc, StringRef Namespace,
-                                         PragmaMessageKind Kind,
-                                         StringRef Str) {
+void PreprocessorProcessor::PragmaMessage(SourceLocation Loc,
+                                          StringRef Namespace,
+                                          PragmaMessageKind Kind,
+                                          StringRef Str) {
   // #pragma warning or #pragma message
   PreprocDirectKind kind = (Kind == PMK_Warning) ? PreprocDirectKind::WARNING
-                                                  : PreprocDirectKind::ERROR;
+                                                 : PreprocDirectKind::ERROR;
   int dir_id = processDirective(Loc, kind);
   extractDirectiveText(Loc, dir_id, kind);
 }
 
-void PreprocessorProcessor::PragmaDebug(SourceLocation Loc, StringRef DebugType) {
+void PreprocessorProcessor::PragmaDebug(SourceLocation Loc,
+                                        StringRef DebugType) {
   int dir_id = processDirective(Loc, PreprocDirectKind::PRAGMA);
   extractDirectiveText(Loc, dir_id, PreprocDirectKind::PRAGMA);
 }
@@ -199,9 +239,18 @@ void PreprocessorProcessor::PragmaDebug(SourceLocation Loc, StringRef DebugType)
 //////////////////////////////////////////////////////////////////////////////
 
 int PreprocessorProcessor::processDirective(SourceLocation Loc,
-                                           PreprocDirectKind kind) {
+                                            PreprocDirectKind kind,
+                                            const std::string &key_suffix) {
+  const SourceManager &SM = preprocessor_->getSourceManager();
+  // Normalize to file location for stable key generation.
+  SourceLocation file_loc = SM.getFileLoc(Loc);
+  std::string filename = SM.getFilename(file_loc).str();
+  unsigned line = SM.getSpellingLineNumber(file_loc);
+  unsigned column = SM.getSpellingColumnNumber(file_loc);
+
   // Check cache first
-  KeyType key = KeyGen::Preprocessor::makeKey(Loc, *preprocessor_);
+  KeyType key = KeyGen::Preprocessor::makeKey(
+      filename, line, column, static_cast<int>(kind), key_suffix);
   auto cached_id = SEARCH_PREPROC_CACHE(key);
   if (cached_id.has_value()) {
     return *cached_id;
@@ -226,17 +275,19 @@ int PreprocessorProcessor::processDirective(SourceLocation Loc,
 }
 
 void PreprocessorProcessor::extractDirectiveText(SourceLocation Loc,
-                                                int directive_id,
-                                                PreprocDirectKind kind) {
+                                                 int directive_id,
+                                                 PreprocDirectKind kind) {
   const SourceManager &SM = ast_context_->getSourceManager();
 
   // Get the start of the line containing the directive
   SourceLocation LineStart = SM.getExpansionLoc(Loc);
 
   // Try to get a reasonable amount of text (up to 512 characters)
-  std::string full_text = Lexer::getSourceText(
-      CharSourceRange::getTokenRange(LineStart, LineStart.getLocWithOffset(512)),
-      SM, LangOptions()).str();
+  std::string full_text =
+      Lexer::getSourceText(CharSourceRange::getTokenRange(
+                               LineStart, LineStart.getLocWithOffset(512)),
+                           SM, LangOptions())
+          .str();
 
   // Truncate at newline
   size_t newline_pos = full_text.find('\n');
@@ -288,7 +339,9 @@ void PreprocessorProcessor::recordBranchPair(int begin_id, int end_id) {
             << std::endl;
 }
 
-void PreprocessorProcessor::recordBranchEvaluation(int branch_id, bool is_true) {
+void PreprocessorProcessor::recordBranchEvaluation(int branch_id,
+                                                   bool is_true) {
+  // Persist branch evaluation result for control-flow reconstruction.
   branch_evaluation_[branch_id] = is_true;
 
   if (is_true) {
@@ -305,6 +358,7 @@ int PreprocessorProcessor::resolveIncludeFile(const std::string &filename) {
   // TODO: Check if file already exists in database to avoid duplicates
 
   int file_id = GENID(File);
+  // Store only basename to keep file table compact and stable.
   std::string file_name = std::filesystem::path(filename).filename().string();
 
   File file = {file_id, file_name};

--- a/src/core/processor/preprocessor_processor.cc
+++ b/src/core/processor/preprocessor_processor.cc
@@ -4,8 +4,10 @@
 #include "util/id_generator.h"
 #include "util/key_generator/preprocessor.h"
 #include "util/logger/macros.h"
+#include <cctype>
 #include <clang/Basic/SourceManager.h>
 #include <clang/Lex/Lexer.h>
+#include <clang/Lex/MacroArgs.h>
 #include <filesystem>
 
 using namespace DbModel;
@@ -162,8 +164,63 @@ void PreprocessorProcessor::MacroExpands(const Token &MacroNameTok,
                                          SourceRange Range,
                                          const MacroArgs *Args) {
   (void)MD;
-  (void)Args;
-  recordMacroInvocation(MacroNameTok, Range.getBegin(), kMacroExpansionKind);
+
+  SourceLocation child_loc = Range.getBegin();
+  int invocation_id =
+      recordMacroInvocation(MacroNameTok, child_loc, kMacroExpansionKind);
+  if (invocation_id < 0) {
+    return;
+  }
+
+  if (child_loc.isValid()) {
+    const SourceManager &SM = ast_context_->getSourceManager();
+    unsigned child_key = makeMacroLocationKey(child_loc);
+    macro_invocation_by_loc_key_[child_key] = invocation_id;
+
+    SourceLocation parent_loc = SM.getImmediateMacroCallerLoc(child_loc);
+    if (parent_loc.isValid()) {
+      unsigned parent_key = makeMacroLocationKey(parent_loc);
+      auto parent_it = macro_invocation_by_loc_key_.find(parent_key);
+      if (parent_it != macro_invocation_by_loc_key_.end()) {
+        int parent_id = parent_it->second;
+        if (parent_id != invocation_id &&
+            shouldInsertMacroParentRow(invocation_id)) {
+          MacroParent parent_row = {invocation_id, parent_id};
+          STG.insertClassObj(parent_row);
+        }
+      }
+    }
+  }
+
+  if (Args == nullptr) {
+    return;
+  }
+
+  unsigned num_args = Args->getNumMacroArguments();
+  for (unsigned i = 0; i < num_args; ++i) {
+    const Token *unexpanded_tokens = Args->getUnexpArgument(i);
+    unsigned unexpanded_count = 0;
+    if (unexpanded_tokens) {
+      unexpanded_count = MacroArgs::getArgLength(unexpanded_tokens);
+    }
+
+    std::string unexpanded_text = tokensToText(unexpanded_tokens, unexpanded_count);
+    const std::vector<Token> &expanded_tokens =
+        const_cast<MacroArgs *>(Args)->getPreExpArgument(i, *preprocessor_);
+    std::string expanded_text = tokensToText(expanded_tokens);
+
+    if (shouldInsertMacroArgumentRow(invocation_id, static_cast<int>(i), false)) {
+      MacroArgumentUnexpanded unexpanded_row = {
+          invocation_id, static_cast<int>(i), unexpanded_text};
+      STG.insertClassObj(unexpanded_row);
+    }
+
+    if (shouldInsertMacroArgumentRow(invocation_id, static_cast<int>(i), true)) {
+      MacroArgumentExpanded expanded_row = {
+          invocation_id, static_cast<int>(i), expanded_text};
+      STG.insertClassObj(expanded_row);
+    }
+  }
 }
 
 void PreprocessorProcessor::MacroDefined(const Token &MacroNameTok,
@@ -398,26 +455,113 @@ std::string PreprocessorProcessor::getSourceText(CharSourceRange range) {
   return Lexer::getSourceText(range, SM, LangOptions()).str();
 }
 
-void PreprocessorProcessor::recordMacroInvocation(const Token &MacroNameTok,
-                                                  SourceLocation Loc, int kind) {
+std::string PreprocessorProcessor::tokensToText(const Token *tokens,
+                                                unsigned token_count) const {
+  if (!tokens || token_count == 0) {
+    return "";
+  }
+
+  std::string text;
+  for (unsigned idx = 0; idx < token_count; ++idx) {
+    const Token &tok = tokens[idx];
+    if (tok.is(tok::eof)) {
+      continue;
+    }
+
+    bool invalid = false;
+    std::string spelling = preprocessor_->getSpelling(tok, &invalid);
+    if (invalid || spelling.empty()) {
+      continue;
+    }
+
+    if (!text.empty()) {
+      text += " ";
+    }
+    text += spelling;
+  }
+  return text;
+}
+
+std::string
+PreprocessorProcessor::tokensToText(const std::vector<Token> &tokens) const {
+  if (tokens.empty()) {
+    return "";
+  }
+
+  std::string text;
+  for (const Token &tok : tokens) {
+    if (tok.is(tok::eof)) {
+      continue;
+    }
+
+    bool invalid = false;
+    std::string spelling = preprocessor_->getSpelling(tok, &invalid);
+    if (invalid || spelling.empty()) {
+      continue;
+    }
+
+    if (!text.empty()) {
+      text += " ";
+    }
+    text += spelling;
+  }
+  return text;
+}
+
+bool PreprocessorProcessor::shouldInsertMacroArgumentRow(int invocation_id,
+                                                         int argument_index,
+                                                         bool is_expanded) {
+  const std::string key =
+      std::to_string(invocation_id) + ":" + std::to_string(argument_index) +
+      ":" + (is_expanded ? "E" : "U");
+  return macro_argument_dedup_cache_.insert(key).second;
+}
+
+bool PreprocessorProcessor::shouldInsertMacroLocationBindRow(int invocation_id,
+                                                             int location_id) {
+  const std::string key =
+      std::to_string(invocation_id) + ":" + std::to_string(location_id);
+  return macrolocationbind_dedup_cache_.insert(key).second;
+}
+
+bool PreprocessorProcessor::shouldInsertMacroParentRow(int child_id) {
+  return macroparent_child_dedup_cache_.insert(child_id).second;
+}
+
+unsigned PreprocessorProcessor::makeMacroLocationKey(SourceLocation loc) const {
+  if (loc.isInvalid()) {
+    return 0;
+  }
+  return loc.getRawEncoding();
+}
+
+int PreprocessorProcessor::recordMacroInvocation(const Token &MacroNameTok,
+                                                 SourceLocation Loc, int kind) {
   const auto *identifier = MacroNameTok.getIdentifierInfo();
   if (!identifier) {
-    return;
+    return -1;
   }
 
   auto it = macro_define_id_by_name_.find(identifier->getName().str());
   if (it == macro_define_id_by_name_.end()) {
-    return;
+    return -1;
   }
 
   const SourceManager &SM = ast_context_->getSourceManager();
   SourceLocation file_loc = SM.getFileLoc(SM.getSpellingLoc(Loc));
   if (!SM.isWrittenInMainFile(file_loc)) {
-    return;
+    return -1;
   }
 
   LocIdPair *loc_pair = PROC_DEFT(file_loc, file_loc, ast_context_);
   int invocation_id = GENID(MacroInvocation);
   MacroInvocation invocation = {invocation_id, it->second, loc_pair->spec_id, kind};
   STG.insertClassObj(invocation);
+
+  if (loc_pair &&
+      shouldInsertMacroLocationBindRow(invocation_id, loc_pair->location_id)) {
+    MacroLocationBind location_bind = {invocation_id, loc_pair->location_id};
+    STG.insertClassObj(location_bind);
+  }
+  return invocation_id;
 }

--- a/src/db/storage_facade_instantiations.inc
+++ b/src/db/storage_facade_instantiations.inc
@@ -58,7 +58,11 @@ template void StorageFacade::insertClassObj<DbModel::Location&>(DbModel::Locatio
 template void StorageFacade::insertClassObj<DbModel::LocationDefault&>(DbModel::LocationDefault&);
 template void StorageFacade::insertClassObj<DbModel::LocationExpr&>(DbModel::LocationExpr&);
 template void StorageFacade::insertClassObj<DbModel::LocationStmt&>(DbModel::LocationStmt&);
+template void StorageFacade::insertClassObj<DbModel::MacroArgumentExpanded&>(DbModel::MacroArgumentExpanded&);
+template void StorageFacade::insertClassObj<DbModel::MacroArgumentUnexpanded&>(DbModel::MacroArgumentUnexpanded&);
 template void StorageFacade::insertClassObj<DbModel::MacroInvocation&>(DbModel::MacroInvocation&);
+template void StorageFacade::insertClassObj<DbModel::MacroLocationBind&>(DbModel::MacroLocationBind&);
+template void StorageFacade::insertClassObj<DbModel::MacroParent&>(DbModel::MacroParent&);
 template void StorageFacade::insertClassObj<DbModel::Member&>(DbModel::Member&);
 template void StorageFacade::insertClassObj<DbModel::MemberVar&>(DbModel::MemberVar&);
 template void StorageFacade::insertClassObj<DbModel::Namespace&>(DbModel::Namespace&);

--- a/src/db/storage_facade_instantiations.inc
+++ b/src/db/storage_facade_instantiations.inc
@@ -58,6 +58,7 @@ template void StorageFacade::insertClassObj<DbModel::Location&>(DbModel::Locatio
 template void StorageFacade::insertClassObj<DbModel::LocationDefault&>(DbModel::LocationDefault&);
 template void StorageFacade::insertClassObj<DbModel::LocationExpr&>(DbModel::LocationExpr&);
 template void StorageFacade::insertClassObj<DbModel::LocationStmt&>(DbModel::LocationStmt&);
+template void StorageFacade::insertClassObj<DbModel::MacroDef&>(DbModel::MacroDef&);
 template void StorageFacade::insertClassObj<DbModel::Member&>(DbModel::Member&);
 template void StorageFacade::insertClassObj<DbModel::MemberVar&>(DbModel::MemberVar&);
 template void StorageFacade::insertClassObj<DbModel::Namespace&>(DbModel::Namespace&);

--- a/src/db/storage_facade_instantiations.inc
+++ b/src/db/storage_facade_instantiations.inc
@@ -58,7 +58,7 @@ template void StorageFacade::insertClassObj<DbModel::Location&>(DbModel::Locatio
 template void StorageFacade::insertClassObj<DbModel::LocationDefault&>(DbModel::LocationDefault&);
 template void StorageFacade::insertClassObj<DbModel::LocationExpr&>(DbModel::LocationExpr&);
 template void StorageFacade::insertClassObj<DbModel::LocationStmt&>(DbModel::LocationStmt&);
-template void StorageFacade::insertClassObj<DbModel::MacroDef&>(DbModel::MacroDef&);
+template void StorageFacade::insertClassObj<DbModel::MacroInvocation&>(DbModel::MacroInvocation&);
 template void StorageFacade::insertClassObj<DbModel::Member&>(DbModel::Member&);
 template void StorageFacade::insertClassObj<DbModel::MemberVar&>(DbModel::MemberVar&);
 template void StorageFacade::insertClassObj<DbModel::Namespace&>(DbModel::Namespace&);

--- a/src/util/key_generator/preprocessor.cc
+++ b/src/util/key_generator/preprocessor.cc
@@ -1,21 +1,18 @@
 #include "util/key_generator/preprocessor.h"
-#include <clang/Basic/SourceManager.h>
-
-using namespace clang;
 
 namespace KeyGen {
 
 namespace Preprocessor {
 
-KeyType makeKey(SourceLocation Loc, class Preprocessor &PP) {
-  const SourceManager &SM = PP.getSourceManager();
-
-  // Get file path, line, and column for unique key
-  std::string filename = SM.getFilename(Loc).str();
-  unsigned line = SM.getSpellingLineNumber(Loc);
-  unsigned column = SM.getSpellingColumnNumber(Loc);
-
-  return filename + ":" + std::to_string(line) + ":" + std::to_string(column);
+KeyType makeKey(const std::string &filename, unsigned line, unsigned column,
+                int directive_kind, const std::string &extra_tag) {
+  std::string normalized_filename = filename.empty() ? "<invalid>" : filename;
+  KeyType key = normalized_filename + ":" + std::to_string(line) + ":" +
+                std::to_string(column) + ":" +
+                std::to_string(directive_kind);
+  if (!extra_tag.empty())
+    key += ":" + extra_tag;
+  return key;
 }
 
 } // namespace Preprocessor

--- a/tests/macro/macro_basic.cc
+++ b/tests/macro/macro_basic.cc
@@ -1,0 +1,6 @@
+#define PI 3.14
+
+int main() {
+  double x = PI;
+  return 0;
+}

--- a/tests/macro/macro_complex.cc
+++ b/tests/macro/macro_complex.cc
@@ -1,0 +1,23 @@
+#define STR(x) #x
+#define XSTR(x) STR(x)
+#define CAT(a, b) a##b
+#define ADD(a, b) ((a) + (b))
+#define WRAP_ADD(x, y) ADD((x), (y))
+#define TWICE_WRAP(v) WRAP_ADD(v, WRAP_ADD(v, 1))
+#define INNER(x) (x)
+#define MIDDLE(x) INNER(x)
+#define OUTER(x) MIDDLE(x)
+
+int main() {
+  int xy = 7;
+  int pasted = CAT(x, y);
+
+  const char *raw = STR(WRAP_ADD(1, 2));
+  const char *expanded = XSTR(WRAP_ADD(1, 2));
+  const char *chain_text = XSTR(OUTER(7));
+
+  int nested_chain = OUTER(42);
+  int nested = TWICE_WRAP(3);
+  return pasted + nested + nested_chain + (raw[0] == 'W') +
+         (expanded[0] == '(') + (chain_text[0] == '(');
+}

--- a/tests/macro/macro_func.cc
+++ b/tests/macro/macro_func.cc
@@ -1,0 +1,6 @@
+#define ADD(a, b) ((a) + (b))
+
+int main() {
+  int x = ADD(1, 2);
+  return x;
+}


### PR DESCRIPTION
本 PR 完成宏定义与宏调用落库链路的 schema 对齐和完成了29-32项的宏表实现：

1. 移除自定义 macro_defs 表及相关模型/写库逻辑
2. 宏定义统一落在 preprocdirects(kind=7)
3. 宏文本使用 preproctext(head/body)
4. 宏调用写入 macroinvocations，并通过 macro_id 关联 define(id)

已通过以下方式验证：
- 全量编译通过
- 生成 DB 后确认不存在 macro_defs 表
- 两次SQLite 链路查询验证：
  macroinvocations.macro_id -> preprocdirects(kind=7) -> preproctext

本次仅对宏定义 + 宏调用链路进行对齐，已把datatable的28. macroinvocations项done,

Update2.27
本次补全 datatable-list 中 29–32 项宏相关表实现：
1.macroparent：
  （基于 getImmediateMacroCallerLoc 建立宏调用父子关系）
2.macrolocationbind：
  （建立宏调用与 locations 表的绑定关系）
3.macro_argument_unexpanded
4.macro_argument_expanded

已通过以下方式验证：
-表结构生成正常
-count(*) 数据存在
-join 关联正确
-无 orphan 记录
-无重复写入

