### PR TITLE
重构 Template 子系统：提取 TemplateProcessor 并瘦身 ASTVisitor

### DIFF
--- a/include/core/ast_visitor.h
+++ b/include/core/ast_visitor.h
@@ -6,6 +6,7 @@
 #include "core/processor/namespace_processor.h"
 #include "core/processor/specifier_processor.h"
 #include "core/processor/stmt_processor.h"
+#include "core/processor/template_processor.h"
 #include "core/processor/type_processor.h"
 #include "core/processor/variable_processor.h"
 #include <clang/AST/Decl.h>
@@ -32,6 +33,7 @@ private:
   std::unique_ptr<StmtProcessor> stmt_processor_ = nullptr;
   std::unique_ptr<ExprProcessor> expr_processor_ = nullptr;
   std::unique_ptr<SpecifierProcessor> specifier_processor_ = nullptr;
+  std::unique_ptr<TemplateProcessor> template_processor_ = nullptr;
 
 public:
   explicit ASTVisitor(clang::ASTContext *context);

--- a/include/core/processor/template_processor.h
+++ b/include/core/processor/template_processor.h
@@ -1,0 +1,105 @@
+#ifndef _TEMPLATE_PROCESSOR_H_
+#define _TEMPLATE_PROCESSOR_H_
+
+#include "core/processor/base_processor.h"
+#include <llvm/ADT/ArrayRef.h>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace clang {
+class ConceptDecl;
+class ConceptSpecializationExpr;
+class TemplateArgument;
+} // namespace clang
+
+class ExprProcessor;
+class TypeProcessor;
+class VariableProcessor;
+
+class TemplateProcessor : public BaseProcessor {
+public:
+  TemplateProcessor(clang::ASTContext *context, const clang::PrintingPolicy pp,
+                    TypeProcessor *typeProcessor,
+                    ExprProcessor *exprProcessor,
+                    VariableProcessor *variableProcessor)
+      : BaseProcessor(context, pp), type_processor_(typeProcessor),
+        expr_processor_(exprProcessor),
+        variable_processor_(variableProcessor) {
+    (void)type_processor_;
+    (void)expr_processor_;
+    (void)variable_processor_;
+  };
+  ~TemplateProcessor() = default;
+
+  bool shouldInsertClassInstantiation(int to, int from);
+  bool shouldInsertClassTemplateArgument(int typeId, int index, int argType);
+  bool shouldInsertClassTemplateArgumentValue(int typeId, int index,
+                                              int argValue);
+  bool shouldInsertFunctionInstantiation(int to, int from);
+  bool shouldInsertFunctionTemplateArgument(int functionId, int index,
+                                            int argType);
+  bool shouldInsertFunctionTemplateArgumentValue(int functionId, int index,
+                                                 int argValue);
+  bool shouldInsertVariableTemplate(int variableId);
+  bool shouldInsertVariableInstantiation(int to, int from);
+  bool shouldInsertVariableTemplateArgument(int variableId, int index,
+                                            int argType);
+  bool shouldInsertVariableTemplateArgumentValue(int variableId, int index,
+                                                 int argValue);
+  bool shouldInsertTemplateTemplateInstantiation(int to, int from);
+  bool shouldInsertTemplateTemplateArgument(int typeId, int index, int argType);
+  bool shouldInsertConceptInstantiation(int conceptId, int templateId);
+  bool shouldInsertConceptTemplateArgument(int conceptId, int index,
+                                           int argType);
+  bool shouldInsertTypeTemplateTypeConstraint(int typeId, int constraintId);
+  bool shouldInsertIsTypeConstraint(int conceptId);
+  bool shouldInsertNontypeTemplateParameter(int id);
+  bool shouldInsertConceptTemplateArgumentValue(int conceptId, int index,
+                                                int argValue);
+
+  int resolveConceptTemplateId(const clang::ConceptDecl *decl,
+                               clang::ASTContext *context);
+  int resolveConceptSpecializationId(
+      const clang::ConceptSpecializationExpr *expr,
+      clang::ASTContext *context);
+
+private:
+  TypeProcessor *type_processor_ = nullptr;
+  ExprProcessor *expr_processor_ = nullptr;
+  VariableProcessor *variable_processor_ = nullptr;
+
+  std::unordered_set<std::string> classInstantiationDedup;
+  std::unordered_set<std::string> classTemplateArgumentDedup;
+  std::unordered_set<std::string> classTemplateArgumentValueDedup;
+  std::unordered_set<std::string> functionInstantiationDedup;
+  std::unordered_set<std::string> functionTemplateArgumentDedup;
+  std::unordered_set<std::string> functionTemplateArgumentValueDedup;
+  std::unordered_set<std::string> variableTemplateDedup;
+  std::unordered_set<std::string> variableInstantiationDedup;
+  std::unordered_set<std::string> variableTemplateArgumentDedup;
+  std::unordered_set<std::string> variableTemplateArgumentValueDedup;
+  std::unordered_set<std::string> templateTemplateInstantiationDedup;
+  std::unordered_set<std::string> templateTemplateArgumentDedup;
+  std::unordered_set<std::string> conceptInstantiationDedup;
+  std::unordered_set<std::string> conceptTemplateArgumentDedup;
+  std::unordered_set<std::string> typeTemplateTypeConstraintDedup;
+  std::unordered_set<int> isTypeConstraintDedup;
+  std::unordered_set<int> nontypeTemplateParameterDedup;
+  std::unordered_set<std::string> conceptTemplateArgumentValueDedup;
+  std::unordered_map<std::string, int> conceptTemplateIds;
+  std::unordered_map<std::string, int> conceptSpecializationIds;
+
+  static std::string makePairKey(int first, int second);
+  static std::string makeTripleKey(int first, int second, int third);
+  static std::string makeConceptTemplateKey(const clang::ConceptDecl *decl,
+                                            clang::ASTContext *context);
+  static std::string makeTemplateArgumentListKey(
+      llvm::ArrayRef<clang::TemplateArgument> args,
+      clang::ASTContext *context);
+  static std::string makeConceptSpecializationKey(
+      const clang::ConceptSpecializationExpr *expr,
+      clang::ASTContext *context);
+};
+
+#endif // _TEMPLATE_PROCESSOR_H_

--- a/include/core/processor/template_processor.h
+++ b/include/core/processor/template_processor.h
@@ -12,9 +12,14 @@ class ConceptDecl;
 class ConceptSpecializationExpr;
 class Expr;
 class QualType;
+class ASTTemplateArgumentListInfo;
+class ClassTemplateDecl;
 class TemplateArgument;
+class TemplateArgumentList;
 class TemplateArgumentLoc;
+class TemplateSpecializationTypeLoc;
 class TemplateTemplateParmDecl;
+class TemplateTypeParmDecl;
 class VarDecl;
 } // namespace clang
 
@@ -77,6 +82,34 @@ public:
   int resolveTemplateArgumentExprId(const clang::Expr *sourceExpr);
   static const clang::Expr *getTemplateArgumentSourceExpr(
       const clang::TemplateArgumentLoc &argLoc);
+
+  void recordClassTemplateTypeArguments(
+      int typeId, const clang::TemplateArgumentList &templateArgs);
+  void recordClassTemplateArgumentValues(
+      int typeId, const clang::ASTTemplateArgumentListInfo *templateArgs);
+  void recordClassTemplateArgumentValues(
+      int typeId, clang::TemplateSpecializationTypeLoc templateArgs);
+  void recordTemplateTemplateArguments(
+      int typeId, const clang::TemplateArgumentList &templateArgs);
+  void recordTemplateTemplateInstantiations(
+      const clang::ClassTemplateDecl *classTemplateDecl,
+      const clang::TemplateArgumentList &templateArgs);
+  void recordFunctionTemplateTypeArguments(
+      int functionId, const clang::TemplateArgumentList *templateArgs);
+  void recordFunctionTemplateArgumentValues(
+      int functionId, const clang::ASTTemplateArgumentListInfo *templateArgs);
+  void recordFunctionTemplateArgumentValues(
+      int functionId, const clang::TemplateArgumentLoc *templateArgs,
+      unsigned numTemplateArgs);
+  void recordVariableTemplateTypeArguments(
+      int variableId, const clang::TemplateArgumentList &templateArgs);
+  void recordVariableTemplateArgumentValues(
+      int variableId, const clang::ASTTemplateArgumentListInfo *templateArgs);
+  void recordConceptTemplateTypeArguments(
+      int conceptId, llvm::ArrayRef<clang::TemplateArgument> templateArgs);
+  void recordConceptTemplateArgumentValues(
+      int conceptId, const clang::ConceptSpecializationExpr *expr);
+  void recordTemplateTypeConstraint(const clang::TemplateTypeParmDecl *decl);
 
 private:
   TypeProcessor *type_processor_ = nullptr;

--- a/include/core/processor/template_processor.h
+++ b/include/core/processor/template_processor.h
@@ -14,6 +14,9 @@ class Expr;
 class QualType;
 class ASTTemplateArgumentListInfo;
 class ClassTemplateDecl;
+class ClassTemplateSpecializationDecl;
+class FriendDecl;
+class FunctionDecl;
 class TemplateArgument;
 class TemplateArgumentList;
 class TemplateArgumentLoc;
@@ -21,6 +24,7 @@ class TemplateSpecializationTypeLoc;
 class TemplateTemplateParmDecl;
 class TemplateTypeParmDecl;
 class VarDecl;
+class VarTemplateSpecializationDecl;
 } // namespace clang
 
 class ExprProcessor;
@@ -110,6 +114,19 @@ public:
   void recordConceptTemplateArgumentValues(
       int conceptId, const clang::ConceptSpecializationExpr *expr);
   void recordTemplateTypeConstraint(const clang::TemplateTypeParmDecl *decl);
+
+  // ---- Visit* orchestration ----
+  void processFunctionTemplateSpecialization(
+      const clang::FunctionDecl *decl,
+      int functionId);
+  void processVarTemplateSpecialization(
+      const clang::VarTemplateSpecializationDecl *decl,
+      int variableId);
+  void processClassTemplateSpecialization(
+      const clang::ClassTemplateSpecializationDecl *decl);
+  void processFriendDecl(const clang::FriendDecl *decl);
+  void processConceptSpecialization(
+      const clang::ConceptSpecializationExpr *expr);
 
 private:
   TypeProcessor *type_processor_ = nullptr;

--- a/include/core/processor/template_processor.h
+++ b/include/core/processor/template_processor.h
@@ -10,7 +10,12 @@
 namespace clang {
 class ConceptDecl;
 class ConceptSpecializationExpr;
+class Expr;
+class QualType;
 class TemplateArgument;
+class TemplateArgumentLoc;
+class TemplateTemplateParmDecl;
+class VarDecl;
 } // namespace clang
 
 class ExprProcessor;
@@ -63,6 +68,15 @@ public:
   int resolveConceptSpecializationId(
       const clang::ConceptSpecializationExpr *expr,
       clang::ASTContext *context);
+  // ---- 跨领域模板参数解析 ----
+  int resolveVariableEntityId(const clang::VarDecl *decl);
+  int resolveTemplateArgumentTypeId(clang::QualType argType);
+  int resolveTemplateTemplateParmId(
+      const clang::TemplateTemplateParmDecl *decl);
+  int resolveTemplateTemplateArgumentTypeId(const clang::TemplateArgument &arg);
+  int resolveTemplateArgumentExprId(const clang::Expr *sourceExpr);
+  static const clang::Expr *getTemplateArgumentSourceExpr(
+      const clang::TemplateArgumentLoc &argLoc);
 
 private:
   TypeProcessor *type_processor_ = nullptr;

--- a/src/core/ast_visitor.cc
+++ b/src/core/ast_visitor.cc
@@ -30,143 +30,6 @@
 
 namespace {
 
-std::unordered_set<std::string> classInstantiationDedup;
-std::unordered_set<std::string> classTemplateArgumentDedup;
-std::unordered_set<std::string> classTemplateArgumentValueDedup;
-std::unordered_set<std::string> functionInstantiationDedup;
-std::unordered_set<std::string> functionTemplateArgumentDedup;
-std::unordered_set<std::string> functionTemplateArgumentValueDedup;
-std::unordered_set<std::string> variableTemplateDedup;
-std::unordered_set<std::string> variableInstantiationDedup;
-std::unordered_set<std::string> variableTemplateArgumentDedup;
-std::unordered_set<std::string> variableTemplateArgumentValueDedup;
-std::unordered_set<std::string> templateTemplateInstantiationDedup;
-std::unordered_set<std::string> templateTemplateArgumentDedup;
-std::unordered_set<std::string> conceptInstantiationDedup;
-std::unordered_set<std::string> conceptTemplateArgumentDedup;
-std::unordered_set<std::string> typeTemplateTypeConstraintDedup;
-std::unordered_set<int> isTypeConstraintDedup;
-std::unordered_set<int> nontypeTemplateParameterDedup;
-std::unordered_set<std::string> conceptTemplateArgumentValueDedup;
-std::unordered_map<std::string, int> conceptTemplateIds;
-std::unordered_map<std::string, int> conceptSpecializationIds;
-
-struct ConceptSpecializationId {
-  int id;
-};
-
-std::string makePairKey(int first, int second) {
-  return std::to_string(first) + ":" + std::to_string(second);
-}
-
-std::string makeTripleKey(int first, int second, int third) {
-  return std::to_string(first) + ":" + std::to_string(second) + ":" +
-         std::to_string(third);
-}
-
-bool shouldInsertClassInstantiation(int to, int from) {
-  return classInstantiationDedup.insert(makePairKey(to, from)).second;
-}
-
-bool shouldInsertClassTemplateArgument(int typeId, int index, int argType) {
-  return classTemplateArgumentDedup
-      .insert(makeTripleKey(typeId, index, argType))
-      .second;
-}
-
-bool shouldInsertClassTemplateArgumentValue(int typeId, int index,
-                                            int argValue) {
-  return classTemplateArgumentValueDedup
-      .insert(makeTripleKey(typeId, index, argValue))
-      .second;
-}
-
-bool shouldInsertFunctionInstantiation(int to, int from) {
-  return functionInstantiationDedup.insert(makePairKey(to, from)).second;
-}
-
-bool shouldInsertFunctionTemplateArgument(int functionId, int index,
-                                          int argType) {
-  return functionTemplateArgumentDedup
-      .insert(makeTripleKey(functionId, index, argType))
-      .second;
-}
-
-bool shouldInsertFunctionTemplateArgumentValue(int functionId, int index,
-                                               int argValue) {
-  return functionTemplateArgumentValueDedup
-      .insert(makeTripleKey(functionId, index, argValue))
-      .second;
-}
-
-bool shouldInsertVariableTemplate(int variableId) {
-  return variableTemplateDedup.insert(std::to_string(variableId)).second;
-}
-
-bool shouldInsertVariableInstantiation(int to, int from) {
-  return variableInstantiationDedup
-      .insert(makePairKey(to, from))
-      .second;
-}
-
-bool shouldInsertVariableTemplateArgument(int variableId, int index,
-                                          int argType) {
-  return variableTemplateArgumentDedup
-      .insert(makeTripleKey(variableId, index, argType))
-      .second;
-}
-
-bool shouldInsertVariableTemplateArgumentValue(int variableId, int index,
-                                               int argValue) {
-  return variableTemplateArgumentValueDedup
-      .insert(makeTripleKey(variableId, index, argValue))
-      .second;
-}
-
-bool shouldInsertTemplateTemplateInstantiation(int to, int from) {
-  return templateTemplateInstantiationDedup.insert(makePairKey(to, from))
-      .second;
-}
-
-bool shouldInsertTemplateTemplateArgument(int typeId, int index, int argType) {
-  return templateTemplateArgumentDedup
-      .insert(makeTripleKey(typeId, index, argType))
-      .second;
-}
-
-bool shouldInsertConceptInstantiation(int conceptId, int templateId) {
-  return conceptInstantiationDedup.insert(makePairKey(conceptId, templateId))
-      .second;
-}
-
-bool shouldInsertConceptTemplateArgument(int conceptId, int index,
-                                         int argType) {
-  return conceptTemplateArgumentDedup
-      .insert(makeTripleKey(conceptId, index, argType))
-      .second;
-}
-
-bool shouldInsertTypeTemplateTypeConstraint(int typeId, int constraintId) {
-  return typeTemplateTypeConstraintDedup
-      .insert(makePairKey(typeId, constraintId))
-      .second;
-}
-
-bool shouldInsertIsTypeConstraint(int conceptId) {
-  return isTypeConstraintDedup.insert(conceptId).second;
-}
-
-bool shouldInsertNontypeTemplateParameter(int id) {
-  return nontypeTemplateParameterDedup.insert(id).second;
-}
-
-bool shouldInsertConceptTemplateArgumentValue(int conceptId, int index,
-                                              int argValue) {
-  return conceptTemplateArgumentValueDedup
-      .insert(makeTripleKey(conceptId, index, argValue))
-      .second;
-}
-
 int resolveVariableEntityId(const clang::VarDecl *decl,
                             VariableProcessor *variableProcessor,
                             clang::ASTContext *context) {
@@ -263,104 +126,6 @@ int resolveTemplateTemplateArgumentTypeId(const clang::TemplateArgument &arg,
   return -1;
 }
 
-std::string makeConceptTemplateKey(const clang::ConceptDecl *decl,
-                                   clang::ASTContext *context) {
-  if (!decl || !context)
-    return "";
-
-  const clang::ConceptDecl *canonicalDecl = decl->getCanonicalDecl();
-  return KeyGen::Type::makeKey(canonicalDecl, context);
-}
-
-int resolveConceptTemplateId(const clang::ConceptDecl *decl,
-                             clang::ASTContext *context) {
-  if (!decl || !context)
-    return -1;
-
-  const clang::ConceptDecl *canonicalDecl = decl->getCanonicalDecl();
-  std::string conceptKey = makeConceptTemplateKey(canonicalDecl, context);
-  if (conceptKey.empty())
-    return -1;
-
-  if (auto it = conceptTemplateIds.find(conceptKey);
-      it != conceptTemplateIds.end())
-    return it->second;
-
-  LocIdPair *locIdPair = SrcLocRecorder::processDefault(canonicalDecl, context);
-  DbModel::ConceptTemplate conceptTemplate = {
-      GENID(ConceptTemplate), canonicalDecl->getNameAsString(),
-      locIdPair->spec_id};
-
-  conceptTemplateIds.emplace(conceptKey, conceptTemplate.id);
-  STG.insertClassObj(conceptTemplate);
-  return conceptTemplate.id;
-}
-
-std::string makeTemplateArgumentListKey(llvm::ArrayRef<clang::TemplateArgument> args,
-                                        clang::ASTContext *context) {
-  std::string key;
-  llvm::raw_string_ostream os(key);
-  clang::PrintingPolicy policy(context->getLangOpts());
-
-  for (unsigned index = 0; index < args.size(); ++index) {
-    if (index != 0)
-      os << ",";
-    args[index].print(policy, os, true);
-  }
-
-  return os.str();
-}
-
-std::string makeConceptSpecializationKey(
-    const clang::ConceptSpecializationExpr *expr,
-    clang::ASTContext *context) {
-  if (!expr || !context)
-    return "";
-
-  std::string conceptKey = makeConceptTemplateKey(expr->getNamedConcept(),
-                                                  context);
-  if (conceptKey.empty())
-    return "";
-
-  const clang::SourceManager &sourceManager = context->getSourceManager();
-  clang::SourceLocation beginLoc =
-      sourceManager.getSpellingLoc(expr->getBeginLoc());
-  clang::SourceLocation endLoc =
-      sourceManager.getSpellingLoc(expr->getEndLoc());
-
-  std::string locationKey;
-  if (beginLoc.isValid() && endLoc.isValid()) {
-    locationKey =
-        beginLoc.printToString(sourceManager) + "-" +
-        endLoc.printToString(sourceManager);
-  } else if (const auto *specializationDecl = expr->getSpecializationDecl()) {
-    locationKey = "implicit-decl-" + std::to_string(specializationDecl->getID());
-  } else {
-    locationKey =
-        "addr-" + std::to_string(reinterpret_cast<std::uintptr_t>(expr));
-  }
-
-  return conceptKey + "<" +
-         makeTemplateArgumentListKey(expr->getTemplateArguments(), context) +
-         ">@" + locationKey;
-}
-
-int resolveConceptSpecializationId(
-    const clang::ConceptSpecializationExpr *expr,
-    clang::ASTContext *context) {
-  std::string specializationKey = makeConceptSpecializationKey(expr, context);
-  if (specializationKey.empty())
-    return -1;
-
-  if (auto it = conceptSpecializationIds.find(specializationKey);
-      it != conceptSpecializationIds.end())
-    return it->second;
-
-  int conceptId = IDGenerator::generateId<ConceptSpecializationId>();
-  conceptSpecializationIds.emplace(specializationKey, conceptId);
-  return conceptId;
-}
-
 const clang::Expr *
 getTemplateArgumentSourceExpr(const clang::TemplateArgumentLoc &argLoc) {
   const clang::TemplateArgument &arg = argLoc.getArgument();
@@ -413,7 +178,8 @@ int resolveTemplateArgumentExprId(const clang::Expr *sourceExpr,
 
 void recordClassTemplateTypeArguments(
     int typeId, const clang::TemplateArgumentList &templateArgs,
-    TypeProcessor *typeProcessor, clang::ASTContext *context) {
+    TypeProcessor *typeProcessor, TemplateProcessor *templateProcessor,
+    clang::ASTContext *context) {
   if (typeId == -1)
     return;
 
@@ -427,8 +193,8 @@ void recordClassTemplateTypeArguments(
     if (argTypeId == -1)
       continue;
 
-    if (!shouldInsertClassTemplateArgument(typeId, static_cast<int>(index),
-                                           argTypeId))
+    if (!templateProcessor->shouldInsertClassTemplateArgument(
+            typeId, static_cast<int>(index), argTypeId))
       continue;
 
     DbModel::ClassTemplateArgument templateArgument = {
@@ -439,7 +205,8 @@ void recordClassTemplateTypeArguments(
 
 void recordClassTemplateArgumentValues(
     int typeId, const clang::ASTTemplateArgumentListInfo *templateArgs,
-    ExprProcessor *exprProcessor, clang::ASTContext *context) {
+    ExprProcessor *exprProcessor, TemplateProcessor *templateProcessor,
+    clang::ASTContext *context) {
   if (typeId == -1 || !templateArgs)
     return;
 
@@ -452,9 +219,8 @@ void recordClassTemplateArgumentValues(
     if (exprId == -1)
       continue;
 
-    if (!shouldInsertClassTemplateArgumentValue(typeId,
-                                                static_cast<int>(index),
-                                                exprId))
+    if (!templateProcessor->shouldInsertClassTemplateArgumentValue(
+            typeId, static_cast<int>(index), exprId))
       continue;
 
     DbModel::ClassTemplateArgumentValue templateArgumentValue = {
@@ -465,7 +231,8 @@ void recordClassTemplateArgumentValues(
 
 void recordClassTemplateArgumentValues(
     int typeId, clang::TemplateSpecializationTypeLoc templateArgs,
-    ExprProcessor *exprProcessor, clang::ASTContext *context) {
+    ExprProcessor *exprProcessor, TemplateProcessor *templateProcessor,
+    clang::ASTContext *context) {
   if (typeId == -1 || !templateArgs)
     return;
 
@@ -477,9 +244,8 @@ void recordClassTemplateArgumentValues(
     if (exprId == -1)
       continue;
 
-    if (!shouldInsertClassTemplateArgumentValue(typeId,
-                                                static_cast<int>(index),
-                                                exprId))
+    if (!templateProcessor->shouldInsertClassTemplateArgumentValue(
+            typeId, static_cast<int>(index), exprId))
       continue;
 
     DbModel::ClassTemplateArgumentValue templateArgumentValue = {
@@ -490,7 +256,8 @@ void recordClassTemplateArgumentValues(
 
 void recordTemplateTemplateArguments(
     int typeId, const clang::TemplateArgumentList &templateArgs,
-    TypeProcessor *typeProcessor, clang::ASTContext *context) {
+    TypeProcessor *typeProcessor, TemplateProcessor *templateProcessor,
+    clang::ASTContext *context) {
   if (typeId == -1)
     return;
 
@@ -501,7 +268,7 @@ void recordTemplateTemplateArguments(
     if (argTypeId == -1)
       continue;
 
-    if (!shouldInsertTemplateTemplateArgument(
+    if (!templateProcessor->shouldInsertTemplateTemplateArgument(
             typeId, static_cast<int>(index), argTypeId))
       continue;
 
@@ -514,7 +281,8 @@ void recordTemplateTemplateArguments(
 void recordTemplateTemplateInstantiations(
     const clang::ClassTemplateDecl *classTemplateDecl,
     const clang::TemplateArgumentList &templateArgs,
-    TypeProcessor *typeProcessor, clang::ASTContext *context) {
+    TypeProcessor *typeProcessor, TemplateProcessor *templateProcessor,
+    clang::ASTContext *context) {
   if (!classTemplateDecl || !typeProcessor || !context)
     return;
 
@@ -547,7 +315,8 @@ void recordTemplateTemplateInstantiations(
     if (paramId == -1 || argTypeId == -1)
       continue;
 
-    if (!shouldInsertTemplateTemplateInstantiation(argTypeId, paramId))
+    if (!templateProcessor->shouldInsertTemplateTemplateInstantiation(argTypeId,
+                                                                      paramId))
       continue;
 
     DbModel::TemplateTemplateInstantiation instantiation = {argTypeId,
@@ -558,7 +327,8 @@ void recordTemplateTemplateInstantiations(
 
 void recordFunctionTemplateTypeArguments(
     int functionId, const clang::TemplateArgumentList *templateArgs,
-    TypeProcessor *typeProcessor, clang::ASTContext *context) {
+    TypeProcessor *typeProcessor, TemplateProcessor *templateProcessor,
+    clang::ASTContext *context) {
   if (functionId == -1 || !templateArgs)
     return;
 
@@ -572,7 +342,7 @@ void recordFunctionTemplateTypeArguments(
     if (argTypeId == -1)
       continue;
 
-    if (!shouldInsertFunctionTemplateArgument(
+    if (!templateProcessor->shouldInsertFunctionTemplateArgument(
             functionId, static_cast<int>(index), argTypeId))
       continue;
 
@@ -584,7 +354,8 @@ void recordFunctionTemplateTypeArguments(
 
 void recordFunctionTemplateArgumentValues(
     int functionId, const clang::ASTTemplateArgumentListInfo *templateArgs,
-    ExprProcessor *exprProcessor, clang::ASTContext *context) {
+    ExprProcessor *exprProcessor, TemplateProcessor *templateProcessor,
+    clang::ASTContext *context) {
   if (functionId == -1 || !templateArgs)
     return;
 
@@ -597,9 +368,8 @@ void recordFunctionTemplateArgumentValues(
     if (exprId == -1)
       continue;
 
-    if (!shouldInsertFunctionTemplateArgumentValue(functionId,
-                                                   static_cast<int>(index),
-                                                   exprId))
+    if (!templateProcessor->shouldInsertFunctionTemplateArgumentValue(
+            functionId, static_cast<int>(index), exprId))
       continue;
 
     DbModel::FunctionTemplateArgumentValue templateArgumentValue = {
@@ -611,7 +381,7 @@ void recordFunctionTemplateArgumentValues(
 void recordFunctionTemplateArgumentValues(
     int functionId, const clang::TemplateArgumentLoc *templateArgs,
     unsigned numTemplateArgs, ExprProcessor *exprProcessor,
-    clang::ASTContext *context) {
+    TemplateProcessor *templateProcessor, clang::ASTContext *context) {
   if (functionId == -1 || !templateArgs)
     return;
 
@@ -623,9 +393,8 @@ void recordFunctionTemplateArgumentValues(
     if (exprId == -1)
       continue;
 
-    if (!shouldInsertFunctionTemplateArgumentValue(functionId,
-                                                   static_cast<int>(index),
-                                                   exprId))
+    if (!templateProcessor->shouldInsertFunctionTemplateArgumentValue(
+            functionId, static_cast<int>(index), exprId))
       continue;
 
     DbModel::FunctionTemplateArgumentValue templateArgumentValue = {
@@ -636,7 +405,8 @@ void recordFunctionTemplateArgumentValues(
 
 void recordVariableTemplateTypeArguments(
     int variableId, const clang::TemplateArgumentList &templateArgs,
-    TypeProcessor *typeProcessor, clang::ASTContext *context) {
+    TypeProcessor *typeProcessor, TemplateProcessor *templateProcessor,
+    clang::ASTContext *context) {
   if (variableId == -1)
     return;
 
@@ -650,7 +420,7 @@ void recordVariableTemplateTypeArguments(
     if (argTypeId == -1)
       continue;
 
-    if (!shouldInsertVariableTemplateArgument(
+    if (!templateProcessor->shouldInsertVariableTemplateArgument(
             variableId, static_cast<int>(index), argTypeId))
       continue;
 
@@ -662,7 +432,8 @@ void recordVariableTemplateTypeArguments(
 
 void recordVariableTemplateArgumentValues(
     int variableId, const clang::ASTTemplateArgumentListInfo *templateArgs,
-    ExprProcessor *exprProcessor, clang::ASTContext *context) {
+    ExprProcessor *exprProcessor, TemplateProcessor *templateProcessor,
+    clang::ASTContext *context) {
   if (variableId == -1 || !templateArgs)
     return;
 
@@ -675,7 +446,7 @@ void recordVariableTemplateArgumentValues(
     if (exprId == -1)
       continue;
 
-    if (!shouldInsertVariableTemplateArgumentValue(
+    if (!templateProcessor->shouldInsertVariableTemplateArgumentValue(
             variableId, static_cast<int>(index), exprId))
       continue;
 
@@ -687,7 +458,8 @@ void recordVariableTemplateArgumentValues(
 
 void recordConceptTemplateTypeArguments(
     int conceptId, llvm::ArrayRef<clang::TemplateArgument> templateArgs,
-    TypeProcessor *typeProcessor, clang::ASTContext *context) {
+    TypeProcessor *typeProcessor, TemplateProcessor *templateProcessor,
+    clang::ASTContext *context) {
   if (conceptId == -1)
     return;
 
@@ -701,9 +473,8 @@ void recordConceptTemplateTypeArguments(
     if (argTypeId == -1)
       continue;
 
-    if (!shouldInsertConceptTemplateArgument(conceptId,
-                                             static_cast<int>(index),
-                                             argTypeId))
+    if (!templateProcessor->shouldInsertConceptTemplateArgument(
+            conceptId, static_cast<int>(index), argTypeId))
       continue;
 
     DbModel::ConceptTemplateArgument templateArgument = {
@@ -714,7 +485,8 @@ void recordConceptTemplateTypeArguments(
 
 void recordConceptTemplateArgumentValues(
     int conceptId, const clang::ConceptSpecializationExpr *expr,
-    ExprProcessor *exprProcessor, clang::ASTContext *context) {
+    ExprProcessor *exprProcessor, TemplateProcessor *templateProcessor,
+    clang::ASTContext *context) {
   if (conceptId == -1 || !expr || !exprProcessor || !context)
     return;
 
@@ -753,9 +525,8 @@ void recordConceptTemplateArgumentValues(
     if (exprId == -1)
       continue;
 
-    if (!shouldInsertConceptTemplateArgumentValue(conceptId,
-                                                  static_cast<int>(index),
-                                                  exprId))
+    if (!templateProcessor->shouldInsertConceptTemplateArgumentValue(
+            conceptId, static_cast<int>(index), exprId))
       continue;
 
     DbModel::ConceptTemplateArgumentValue row = {conceptId,
@@ -767,6 +538,7 @@ void recordConceptTemplateArgumentValues(
 
 void recordTemplateTypeConstraint(const clang::TemplateTypeParmDecl *decl,
                                   ExprProcessor *exprProcessor,
+                                  TemplateProcessor *templateProcessor,
                                   clang::ASTContext *context) {
   if (!decl || !exprProcessor || !context)
     return;
@@ -787,7 +559,8 @@ void recordTemplateTypeConstraint(const clang::TemplateTypeParmDecl *decl,
   if (templateParamId == -1)
     return;
 
-  int conceptId = resolveConceptSpecializationId(conceptExpr, context);
+  int conceptId = templateProcessor->resolveConceptSpecializationId(conceptExpr,
+                                                                    context);
   if (conceptId == -1)
     return;
 
@@ -796,14 +569,14 @@ void recordTemplateTypeConstraint(const clang::TemplateTypeParmDecl *decl,
   if (constraintExprId == -1)
     return;
 
-  if (shouldInsertTypeTemplateTypeConstraint(templateParamId,
-                                             constraintExprId)) {
+  if (templateProcessor->shouldInsertTypeTemplateTypeConstraint(
+          templateParamId, constraintExprId)) {
     DbModel::TypeTemplateTypeConstraint row = {templateParamId,
                                                constraintExprId};
     STG.insertClassObj(row);
   }
 
-  if (shouldInsertIsTypeConstraint(conceptId)) {
+  if (templateProcessor->shouldInsertIsTypeConstraint(conceptId)) {
     DbModel::IsTypeConstraint row = {conceptId};
     STG.insertClassObj(row);
   }
@@ -826,6 +599,9 @@ void ASTVisitor::initProcessors() {
   stmt_processor_ = std::make_unique<StmtProcessor>(context_, pp_);
   expr_processor_ = std::make_unique<ExprProcessor>(context_, pp_, type_processor_.get());
   specifier_processor_ = std::make_unique<SpecifierProcessor>(context_, pp_);
+  template_processor_ = std::make_unique<TemplateProcessor>(
+      context_, pp_, type_processor_.get(), expr_processor_.get(),
+      variable_processor_.get());
 }
 
 // 实现各种Visit方法
@@ -866,7 +642,8 @@ bool ASTVisitor::VisitFunctionDecl(clang::FunctionDecl *decl) {
       KeyType templateKey = KeyGen::Function::makeKey(templatedDecl, context_);
 
       if (auto cachedId = SEARCH_FUNCTION_CACHE(templateKey)) {
-        if (shouldInsertFunctionInstantiation(specializationId, *cachedId)) {
+        if (template_processor_->shouldInsertFunctionInstantiation(
+                specializationId, *cachedId)) {
           DbModel::FunctionInstantiation instantiation = {
               specializationId, *cachedId};
           STG.insertClassObj(instantiation);
@@ -874,9 +651,10 @@ bool ASTVisitor::VisitFunctionDecl(clang::FunctionDecl *decl) {
       } else {
         PendingUpdate update{
             templateKey, CacheType::FUNCTION,
-            [specializationId](int resolvedId) {
-              if (!shouldInsertFunctionInstantiation(specializationId,
-                                                     resolvedId))
+            [specializationId,
+             templateProcessor = template_processor_.get()](int resolvedId) {
+              if (!templateProcessor->shouldInsertFunctionInstantiation(
+                      specializationId, resolvedId))
                 return;
 
               DbModel::FunctionInstantiation instantiation = {
@@ -889,10 +667,10 @@ bool ASTVisitor::VisitFunctionDecl(clang::FunctionDecl *decl) {
 
     recordFunctionTemplateTypeArguments(
         specializationId, decl->getTemplateSpecializationArgs(),
-        type_processor_.get(), context_);
+        type_processor_.get(), template_processor_.get(), context_);
     recordFunctionTemplateArgumentValues(
         specializationId, decl->getTemplateSpecializationArgsAsWritten(),
-        expr_processor_.get(), context_);
+        expr_processor_.get(), template_processor_.get(), context_);
   }
 
   return true;
@@ -931,7 +709,8 @@ bool ASTVisitor::VisitVarDecl(clang::VarDecl *decl) {
     auto templateTypeLoc = typeInfo->getTypeLoc()
                                .getAsAdjusted<clang::TemplateSpecializationTypeLoc>();
     recordClassTemplateArgumentValues(type_id, templateTypeLoc,
-                                      expr_processor_.get(), context_);
+                                      expr_processor_.get(),
+                                      template_processor_.get(), context_);
   }
 
   if (const auto *specialization =
@@ -949,7 +728,8 @@ bool ASTVisitor::VisitVarDecl(clang::VarDecl *decl) {
           primaryTemplate->getTemplatedDecl(), variable_processor_.get(),
           context_);
       if (templateId != -1 &&
-          shouldInsertVariableInstantiation(variableId, templateId)) {
+          template_processor_->shouldInsertVariableInstantiation(variableId,
+                                                                 templateId)) {
         DbModel::VariableInstantiation instantiation = {variableId,
                                                         templateId};
         STG.insertClassObj(instantiation);
@@ -958,10 +738,10 @@ bool ASTVisitor::VisitVarDecl(clang::VarDecl *decl) {
 
     recordVariableTemplateTypeArguments(
         variableId, specialization->getTemplateInstantiationArgs(),
-        type_processor_.get(), context_);
+        type_processor_.get(), template_processor_.get(), context_);
     recordVariableTemplateArgumentValues(
         variableId, specialization->getTemplateArgsAsWritten(),
-        expr_processor_.get(), context_);
+        expr_processor_.get(), template_processor_.get(), context_);
   }
   return true;
 }
@@ -1016,7 +796,8 @@ bool ASTVisitor::VisitTypedefDecl(clang::TypedefDecl *decl) {
 
 bool ASTVisitor::VisitTemplateTypeParmDecl(clang::TemplateTypeParmDecl *decl) {
   type_processor_->processTemplateTypeParmDecl(decl);
-  recordTemplateTypeConstraint(decl, expr_processor_.get(), context_);
+  recordTemplateTypeConstraint(decl, expr_processor_.get(),
+                               template_processor_.get(), context_);
   return true;
 }
 
@@ -1035,7 +816,7 @@ bool ASTVisitor::VisitNonTypeTemplateParmDecl(
   if (exprId == -1)
     return true;
 
-  if (shouldInsertNontypeTemplateParameter(exprId)) {
+  if (template_processor_->shouldInsertNontypeTemplateParameter(exprId)) {
     DbModel::NonTypeTemplateParameter row = {exprId};
     STG.insertClassObj(row);
   }
@@ -1186,7 +967,7 @@ bool ASTVisitor::VisitFriendDecl(clang::FriendDecl *decl) {
 }
 
 bool ASTVisitor::VisitConceptDecl(clang::ConceptDecl *decl) {
-  resolveConceptTemplateId(decl, context_);
+  template_processor_->resolveConceptTemplateId(decl, context_);
   return true;
 }
 
@@ -1257,7 +1038,8 @@ bool ASTVisitor::VisitClassTemplateSpecializationDecl(
     templateId = *cachedId;
 
   if (specializationId != -1 && templateId != -1) {
-    if (shouldInsertClassInstantiation(specializationId, templateId)) {
+    if (template_processor_->shouldInsertClassInstantiation(specializationId,
+                                                            templateId)) {
       DbModel::ClassInstantiation instantiation = {specializationId,
                                                    templateId};
       STG.insertClassObj(instantiation);
@@ -1266,16 +1048,16 @@ bool ASTVisitor::VisitClassTemplateSpecializationDecl(
 
   recordClassTemplateTypeArguments(
       specializationId, decl->getTemplateInstantiationArgs(),
-      type_processor_.get(), context_);
+      type_processor_.get(), template_processor_.get(), context_);
   recordTemplateTemplateArguments(
       specializationId, decl->getTemplateInstantiationArgs(),
-      type_processor_.get(), context_);
+      type_processor_.get(), template_processor_.get(), context_);
   recordTemplateTemplateInstantiations(
       classTemplateDecl, decl->getTemplateInstantiationArgs(),
-      type_processor_.get(), context_);
+      type_processor_.get(), template_processor_.get(), context_);
   recordClassTemplateArgumentValues(
       specializationId, decl->getTemplateArgsAsWritten(), expr_processor_.get(),
-      context_);
+      template_processor_.get(), context_);
 
   return true;
 }
@@ -1315,7 +1097,8 @@ bool ASTVisitor::VisitVarTemplateDecl(clang::VarTemplateDecl *decl) {
   int variableId =
       resolveVariableEntityId(templatedDecl, variable_processor_.get(),
                               context_);
-  if (variableId == -1 || !shouldInsertVariableTemplate(variableId))
+  if (variableId == -1 ||
+      !template_processor_->shouldInsertVariableTemplate(variableId))
     return true;
 
   DbModel::IsVariableTemplate isVariableTemplate = {variableId};
@@ -1336,7 +1119,7 @@ bool ASTVisitor::VisitDeclRefExpr(clang::DeclRefExpr *expr) {
       int functionId = SEARCH_FUNCTION_CACHE(functionKey).value_or(-1);
       recordFunctionTemplateArgumentValues(
           functionId, expr->getTemplateArgs(), expr->getNumTemplateArgs(),
-          expr_processor_.get(), context_);
+          expr_processor_.get(), template_processor_.get(), context_);
     }
   }
 
@@ -1413,24 +1196,28 @@ bool ASTVisitor::VisitConceptSpecializationExpr(
   if (!expr)
     return true;
 
-  int templateId = resolveConceptTemplateId(expr->getNamedConcept(), context_);
+  int templateId = template_processor_->resolveConceptTemplateId(
+      expr->getNamedConcept(), context_);
   if (templateId == -1)
     return true;
 
-  int conceptId = resolveConceptSpecializationId(expr, context_);
+  int conceptId = template_processor_->resolveConceptSpecializationId(expr,
+                                                                      context_);
   if (conceptId == -1)
     return true;
 
   expr_processor_->processConceptSpecializationExpr(expr, conceptId);
 
-  if (shouldInsertConceptInstantiation(conceptId, templateId)) {
+  if (template_processor_->shouldInsertConceptInstantiation(conceptId,
+                                                            templateId)) {
     DbModel::ConceptInstantiation instantiation = {conceptId, templateId};
     STG.insertClassObj(instantiation);
   }
 
   recordConceptTemplateTypeArguments(conceptId, expr->getTemplateArguments(),
-                                     type_processor_.get(), context_);
+                                     type_processor_.get(),
+                                     template_processor_.get(), context_);
   recordConceptTemplateArgumentValues(conceptId, expr, expr_processor_.get(),
-                                      context_);
+                                      template_processor_.get(), context_);
   return true;
 }

--- a/src/core/ast_visitor.cc
+++ b/src/core/ast_visitor.cc
@@ -71,49 +71,7 @@ bool ASTVisitor::VisitFunctionDecl(clang::FunctionDecl *decl) {
                                                 param->getType());
   }
 
-  if (decl && decl->isFunctionTemplateSpecialization()) {
-    KeyType functionKey = KeyGen::Function::makeKey(decl, context_);
-    int specializationId = func_id;
-    if (auto cachedId = SEARCH_FUNCTION_CACHE(functionKey))
-      specializationId = *cachedId;
-    if (specializationId == -1)
-      return true;
-
-    if (const clang::FunctionTemplateDecl *primaryTemplate =
-            decl->getPrimaryTemplate()) {
-      const clang::FunctionDecl *templatedDecl =
-          primaryTemplate->getTemplatedDecl();
-      KeyType templateKey = KeyGen::Function::makeKey(templatedDecl, context_);
-
-      if (auto cachedId = SEARCH_FUNCTION_CACHE(templateKey)) {
-        if (template_processor_->shouldInsertFunctionInstantiation(
-                specializationId, *cachedId)) {
-          DbModel::FunctionInstantiation instantiation = {
-              specializationId, *cachedId};
-          STG.insertClassObj(instantiation);
-        }
-      } else {
-        PendingUpdate update{
-            templateKey, CacheType::FUNCTION,
-            [specializationId,
-             templateProcessor = template_processor_.get()](int resolvedId) {
-              if (!templateProcessor->shouldInsertFunctionInstantiation(
-                      specializationId, resolvedId))
-                return;
-
-              DbModel::FunctionInstantiation instantiation = {
-                  specializationId, resolvedId};
-              STG.insertClassObj(instantiation);
-            }};
-        DependencyManager::instance().addDependency(update);
-      }
-    }
-
-    template_processor_->recordFunctionTemplateTypeArguments(
-        specializationId, decl->getTemplateSpecializationArgs());
-    template_processor_->recordFunctionTemplateArgumentValues(
-        specializationId, decl->getTemplateSpecializationArgsAsWritten());
-  }
+  template_processor_->processFunctionTemplateSpecialization(decl, func_id);
 
   return true;
 }
@@ -154,32 +112,9 @@ bool ASTVisitor::VisitVarDecl(clang::VarDecl *decl) {
                                                            templateTypeLoc);
   }
 
-  if (const auto *specialization =
-          llvm::dyn_cast_or_null<clang::VarTemplateSpecializationDecl>(decl)) {
-    int variableId =
-        template_processor_->resolveVariableEntityId(specialization);
-    if (variableId == -1)
-      return true;
-
-    const clang::VarTemplateDecl *primaryTemplate =
-        specialization->getSpecializedTemplate();
-    if (primaryTemplate && primaryTemplate->getTemplatedDecl()) {
-      int templateId = template_processor_->resolveVariableEntityId(
-          primaryTemplate->getTemplatedDecl());
-      if (templateId != -1 &&
-          template_processor_->shouldInsertVariableInstantiation(variableId,
-                                                                 templateId)) {
-        DbModel::VariableInstantiation instantiation = {variableId,
-                                                        templateId};
-        STG.insertClassObj(instantiation);
-      }
-    }
-
-    template_processor_->recordVariableTemplateTypeArguments(
-        variableId, specialization->getTemplateInstantiationArgs());
-    template_processor_->recordVariableTemplateArgumentValues(
-        variableId, specialization->getTemplateArgsAsWritten());
-  }
+  template_processor_->processVarTemplateSpecialization(
+      llvm::dyn_cast_or_null<clang::VarTemplateSpecializationDecl>(decl),
+      var_decl_id);
   return true;
 }
 
@@ -335,70 +270,7 @@ bool ASTVisitor::VisitCompoundStmt(clang::CompoundStmt *compoundStmt) {
 }
 
 bool ASTVisitor::VisitFriendDecl(clang::FriendDecl *decl) {
-  if (!decl)
-    return true;
-
-  LocIdPair *locIdPair = SrcLocRecorder::processDefault(decl, context_);
-  const int friendDeclId = GENID(FriendDecl);
-  int typeId = -1;
-  int declId = -1;
-
-  auto resolveRecordType = [&](const clang::RecordType *recordType) -> int {
-    if (!recordType || !recordType->getDecl())
-      return -1;
-
-    type_processor_->processRecordType(recordType);
-    KeyType typeKey = KeyGen::Type::makeKey(recordType->getDecl(), context_);
-    if (auto cachedId = SEARCH_TYPE_CACHE(typeKey))
-      return *cachedId;
-
-    return -1;
-  };
-
-  auto resolveFriendType = [&](clang::QualType friendType) -> int {
-    if (friendType.isNull())
-      return -1;
-
-    if (const auto *recordType = friendType->getAs<clang::RecordType>())
-      return resolveRecordType(recordType);
-
-    return type_processor_->processType(friendType.getTypePtr());
-  };
-
-  if (clang::TypeSourceInfo *friendTypeInfo = decl->getFriendType()) {
-    typeId = resolveFriendType(friendTypeInfo->getType());
-  } else if (clang::NamedDecl *friendNamedDecl = decl->getFriendDecl()) {
-    if (const auto *functionDecl =
-            llvm::dyn_cast<clang::FunctionDecl>(friendNamedDecl)) {
-      KeyType functionKey = KeyGen::Function::makeKey(functionDecl, context_);
-      if (auto cachedId = SEARCH_FUNCTION_CACHE(functionKey)) {
-        declId = *cachedId;
-      } else {
-        PendingUpdate update{
-            functionKey, CacheType::FUNCTION,
-            [friendDeclId, typeId, location = locIdPair->spec_id](
-                int resolvedId) {
-              DbModel::FriendDecl updatedRecord = {friendDeclId, typeId,
-                                                   resolvedId, location};
-              STG.insertClassObj(updatedRecord);
-            }};
-        DependencyManager::instance().addDependency(update);
-      }
-    } else if (const auto *typeDecl =
-                   llvm::dyn_cast<clang::TypeDecl>(friendNamedDecl)) {
-      if (const auto *recordDecl =
-              llvm::dyn_cast<clang::RecordDecl>(typeDecl)) {
-        if (const auto *recordType =
-                llvm::dyn_cast_or_null<clang::RecordType>(
-                    recordDecl->getTypeForDecl()))
-          typeId = resolveRecordType(recordType);
-      }
-    }
-  }
-
-  DbModel::FriendDecl friendDeclModel = {friendDeclId, typeId, declId,
-                                         locIdPair->spec_id};
-  STG.insertClassObj(friendDeclModel);
+  template_processor_->processFriendDecl(decl);
   return true;
 }
 
@@ -440,57 +312,7 @@ bool ASTVisitor::VisitClassTemplateDecl(clang::ClassTemplateDecl *decl) {
 
 bool ASTVisitor::VisitClassTemplateSpecializationDecl(
     clang::ClassTemplateSpecializationDecl *decl) {
-  if (!decl)
-    return true;
-
-  const clang::ClassTemplateDecl *classTemplateDecl = nullptr;
-  auto instantiatedFrom = decl->getInstantiatedFrom();
-  if (!instantiatedFrom.isNull())
-    classTemplateDecl = instantiatedFrom.dyn_cast<clang::ClassTemplateDecl *>();
-  if (!classTemplateDecl)
-    classTemplateDecl = decl->getSpecializedTemplate();
-  if (!classTemplateDecl)
-    return true;
-
-  const clang::CXXRecordDecl *templatedDecl =
-      classTemplateDecl->getTemplatedDecl();
-  if (!templatedDecl)
-    return true;
-
-  KeyType specializationKey = KeyGen::Type::makeKey(decl, context_);
-  if (!SEARCH_TYPE_CACHE(specializationKey))
-    type_processor_->processRecordDeclType(decl);
-
-  KeyType templateKey = KeyGen::Type::makeKey(templatedDecl, context_);
-  if (!SEARCH_TYPE_CACHE(templateKey))
-    type_processor_->processRecordDeclType(templatedDecl);
-
-  int specializationId = -1;
-  int templateId = -1;
-
-  if (auto cachedId = SEARCH_TYPE_CACHE(specializationKey))
-    specializationId = *cachedId;
-  if (auto cachedId = SEARCH_TYPE_CACHE(templateKey))
-    templateId = *cachedId;
-
-  if (specializationId != -1 && templateId != -1) {
-    if (template_processor_->shouldInsertClassInstantiation(specializationId,
-                                                            templateId)) {
-      DbModel::ClassInstantiation instantiation = {specializationId,
-                                                   templateId};
-      STG.insertClassObj(instantiation);
-    }
-  }
-
-  template_processor_->recordClassTemplateTypeArguments(
-      specializationId, decl->getTemplateInstantiationArgs());
-  template_processor_->recordTemplateTemplateArguments(
-      specializationId, decl->getTemplateInstantiationArgs());
-  template_processor_->recordTemplateTemplateInstantiations(
-      classTemplateDecl, decl->getTemplateInstantiationArgs());
-  template_processor_->recordClassTemplateArgumentValues(
-      specializationId, decl->getTemplateArgsAsWritten());
-
+  template_processor_->processClassTemplateSpecialization(decl);
   return true;
 }
 
@@ -622,29 +444,6 @@ bool ASTVisitor::VisitUnaryExprOrTypeTraitExpr(clang::UnaryExprOrTypeTraitExpr *
 
 bool ASTVisitor::VisitConceptSpecializationExpr(
     clang::ConceptSpecializationExpr *expr) {
-  if (!expr)
-    return true;
-
-  int templateId = template_processor_->resolveConceptTemplateId(
-      expr->getNamedConcept(), context_);
-  if (templateId == -1)
-    return true;
-
-  int conceptId = template_processor_->resolveConceptSpecializationId(expr,
-                                                                      context_);
-  if (conceptId == -1)
-    return true;
-
-  expr_processor_->processConceptSpecializationExpr(expr, conceptId);
-
-  if (template_processor_->shouldInsertConceptInstantiation(conceptId,
-                                                            templateId)) {
-    DbModel::ConceptInstantiation instantiation = {conceptId, templateId};
-    STG.insertClassObj(instantiation);
-  }
-
-  template_processor_->recordConceptTemplateTypeArguments(
-      conceptId, expr->getTemplateArguments());
-  template_processor_->recordConceptTemplateArgumentValues(conceptId, expr);
+  template_processor_->processConceptSpecialization(expr);
   return true;
 }

--- a/src/core/ast_visitor.cc
+++ b/src/core/ast_visitor.cc
@@ -30,156 +30,13 @@
 
 namespace {
 
-int resolveVariableEntityId(const clang::VarDecl *decl,
-                            VariableProcessor *variableProcessor,
-                            clang::ASTContext *context) {
-  if (!decl || !variableProcessor || !context)
-    return -1;
-
-  KeyType variableKey = KeyGen::Var::makeKey(decl, context);
-  if (auto cachedId = SEARCH_VARIABLE_CACHE(variableKey))
-    return *cachedId;
-
-  variableProcessor->processVarDecl(decl);
-  if (auto cachedId = SEARCH_VARIABLE_CACHE(variableKey))
-    return *cachedId;
-
-  return -1;
-}
-
-int resolveTemplateArgumentTypeId(clang::QualType argType,
-                                  TypeProcessor *typeProcessor,
-                                  clang::ASTContext *context) {
-  if (argType.isNull() || !typeProcessor || !context)
-    return -1;
-
-  KeyType typeKey = KeyGen::Type::makeKey(argType, context);
-  if (auto cachedId = SEARCH_TYPE_CACHE(typeKey))
-    return *cachedId;
-
-  if (const auto *builtinType = argType->getAs<clang::BuiltinType>())
-    return typeProcessor->processBuiltinType(builtinType, context);
-
-  if (const auto *recordType = argType->getAs<clang::RecordType>()) {
-    typeProcessor->processRecordType(recordType);
-    if (auto cachedId = SEARCH_TYPE_CACHE(typeKey))
-      return *cachedId;
-  }
-
-  int typeId = typeProcessor->processType(argType.getTypePtr());
-  if (typeId != -1)
-    return typeId;
-
-  if (auto cachedId = SEARCH_TYPE_CACHE(typeKey))
-    return *cachedId;
-
-  return -1;
-}
-
-int resolveTemplateTemplateParmId(const clang::TemplateTemplateParmDecl *decl,
-                                  TypeProcessor *typeProcessor,
-                                  clang::ASTContext *context) {
-  if (!decl || !typeProcessor || !context)
-    return -1;
-
-  KeyType typeKey = KeyGen::Type::makeKey(decl, context);
-  if (auto cachedId = SEARCH_TYPE_CACHE(typeKey))
-    return *cachedId;
-
-  int typeId = typeProcessor->processTemplateTemplateParmDecl(decl);
-  if (typeId != -1)
-    return typeId;
-
-  if (auto cachedId = SEARCH_TYPE_CACHE(typeKey))
-    return *cachedId;
-
-  return -1;
-}
-
-int resolveTemplateTemplateArgumentTypeId(const clang::TemplateArgument &arg,
-                                          TypeProcessor *typeProcessor,
-                                          clang::ASTContext *context) {
-  if (arg.getKind() != clang::TemplateArgument::Template || !typeProcessor ||
-      !context)
-    return -1;
-
-  const clang::TemplateDecl *templateDecl =
-      arg.getAsTemplate().getAsTemplateDecl();
-  const auto *classTemplateDecl =
-      llvm::dyn_cast_or_null<clang::ClassTemplateDecl>(templateDecl);
-  if (!classTemplateDecl || !classTemplateDecl->getTemplatedDecl())
-    return -1;
-
-  const clang::CXXRecordDecl *templatedDecl =
-      classTemplateDecl->getTemplatedDecl();
-  KeyType templateTypeKey = KeyGen::Type::makeKey(templatedDecl, context);
-  if (auto cachedId = SEARCH_TYPE_CACHE(templateTypeKey))
-    return *cachedId;
-
-  int templateTypeId = typeProcessor->processRecordDeclType(templatedDecl);
-  if (templateTypeId != -1)
-    return templateTypeId;
-
-  if (auto cachedId = SEARCH_TYPE_CACHE(templateTypeKey))
-    return *cachedId;
-
-  return -1;
-}
-
-const clang::Expr *
-getTemplateArgumentSourceExpr(const clang::TemplateArgumentLoc &argLoc) {
-  const clang::TemplateArgument &arg = argLoc.getArgument();
-
-  switch (arg.getKind()) {
-  case clang::TemplateArgument::Expression:
-    return argLoc.getSourceExpression();
-  case clang::TemplateArgument::Integral:
-    return argLoc.getSourceIntegralExpression();
-  default:
-    return nullptr;
-  }
-}
-
-int resolveTemplateArgumentExprId(const clang::Expr *sourceExpr,
-                                  ExprProcessor *exprProcessor,
-                                  clang::ASTContext *context) {
-  if (!sourceExpr || !exprProcessor || !context)
-    return -1;
-
-  const clang::Expr *expr = sourceExpr->IgnoreParenImpCasts();
-  KeyType exprKey = KeyGen::Expr_::makeKey(expr, context);
-  if (auto cachedId = SEARCH_EXPR_CACHE(exprKey))
-    return *cachedId;
-
-  if (const auto *integerLiteral =
-          llvm::dyn_cast<clang::IntegerLiteral>(expr)) {
-    exprProcessor->processIntegerLiteral(integerLiteral);
-  } else if (const auto *floatingLiteral =
-                 llvm::dyn_cast<clang::FloatingLiteral>(expr)) {
-    exprProcessor->processFloatingLiteral(floatingLiteral);
-  } else if (const auto *characterLiteral =
-                 llvm::dyn_cast<clang::CharacterLiteral>(expr)) {
-    exprProcessor->processCharacterLiteral(characterLiteral);
-  } else if (const auto *boolLiteral =
-                 llvm::dyn_cast<clang::CXXBoolLiteralExpr>(expr)) {
-    exprProcessor->processBoolLiteral(boolLiteral);
-  } else if (const auto *declRefExpr =
-                 llvm::dyn_cast<clang::DeclRefExpr>(expr)) {
-    exprProcessor->processDeclRef(const_cast<clang::DeclRefExpr *>(declRefExpr));
-  } else {
-    return -1;
-  }
-
-  if (auto cachedId = SEARCH_EXPR_CACHE(exprKey))
-    return *cachedId;
-
-  return -1;
-}
-
 void recordClassTemplateTypeArguments(
     int typeId, const clang::TemplateArgumentList &templateArgs,
     TypeProcessor *typeProcessor, TemplateProcessor *templateProcessor,
     clang::ASTContext *context) {
+  (void)typeProcessor;
+  (void)context;
+
   if (typeId == -1)
     return;
 
@@ -189,7 +46,7 @@ void recordClassTemplateTypeArguments(
       continue;
 
     int argTypeId =
-        resolveTemplateArgumentTypeId(arg.getAsType(), typeProcessor, context);
+        templateProcessor->resolveTemplateArgumentTypeId(arg.getAsType());
     if (argTypeId == -1)
       continue;
 
@@ -207,15 +64,19 @@ void recordClassTemplateArgumentValues(
     int typeId, const clang::ASTTemplateArgumentListInfo *templateArgs,
     ExprProcessor *exprProcessor, TemplateProcessor *templateProcessor,
     clang::ASTContext *context) {
+  (void)exprProcessor;
+  (void)context;
+
   if (typeId == -1 || !templateArgs)
     return;
 
   for (unsigned index = 0; index < templateArgs->getNumTemplateArgs();
        ++index) {
     const clang::TemplateArgumentLoc &argLoc = (*templateArgs)[index];
-    const clang::Expr *sourceExpr = getTemplateArgumentSourceExpr(argLoc);
+    const clang::Expr *sourceExpr =
+        templateProcessor->getTemplateArgumentSourceExpr(argLoc);
     int exprId =
-        resolveTemplateArgumentExprId(sourceExpr, exprProcessor, context);
+        templateProcessor->resolveTemplateArgumentExprId(sourceExpr);
     if (exprId == -1)
       continue;
 
@@ -233,14 +94,18 @@ void recordClassTemplateArgumentValues(
     int typeId, clang::TemplateSpecializationTypeLoc templateArgs,
     ExprProcessor *exprProcessor, TemplateProcessor *templateProcessor,
     clang::ASTContext *context) {
+  (void)exprProcessor;
+  (void)context;
+
   if (typeId == -1 || !templateArgs)
     return;
 
   for (unsigned index = 0; index < templateArgs.getNumArgs(); ++index) {
     const clang::TemplateArgumentLoc &argLoc = templateArgs.getArgLoc(index);
-    const clang::Expr *sourceExpr = getTemplateArgumentSourceExpr(argLoc);
+    const clang::Expr *sourceExpr =
+        templateProcessor->getTemplateArgumentSourceExpr(argLoc);
     int exprId =
-        resolveTemplateArgumentExprId(sourceExpr, exprProcessor, context);
+        templateProcessor->resolveTemplateArgumentExprId(sourceExpr);
     if (exprId == -1)
       continue;
 
@@ -258,13 +123,16 @@ void recordTemplateTemplateArguments(
     int typeId, const clang::TemplateArgumentList &templateArgs,
     TypeProcessor *typeProcessor, TemplateProcessor *templateProcessor,
     clang::ASTContext *context) {
+  (void)typeProcessor;
+  (void)context;
+
   if (typeId == -1)
     return;
 
   for (unsigned index = 0; index < templateArgs.size(); ++index) {
     const clang::TemplateArgument &arg = templateArgs[index];
     int argTypeId =
-        resolveTemplateTemplateArgumentTypeId(arg, typeProcessor, context);
+        templateProcessor->resolveTemplateTemplateArgumentTypeId(arg);
     if (argTypeId == -1)
       continue;
 
@@ -309,9 +177,9 @@ void recordTemplateTemplateInstantiations(
     if (!llvm::isa_and_nonnull<clang::ClassTemplateDecl>(templateDecl))
       continue;
 
-    int paramId = resolveTemplateTemplateParmId(param, typeProcessor, context);
+    int paramId = templateProcessor->resolveTemplateTemplateParmId(param);
     int argTypeId =
-        resolveTemplateTemplateArgumentTypeId(arg, typeProcessor, context);
+        templateProcessor->resolveTemplateTemplateArgumentTypeId(arg);
     if (paramId == -1 || argTypeId == -1)
       continue;
 
@@ -329,6 +197,9 @@ void recordFunctionTemplateTypeArguments(
     int functionId, const clang::TemplateArgumentList *templateArgs,
     TypeProcessor *typeProcessor, TemplateProcessor *templateProcessor,
     clang::ASTContext *context) {
+  (void)typeProcessor;
+  (void)context;
+
   if (functionId == -1 || !templateArgs)
     return;
 
@@ -338,7 +209,7 @@ void recordFunctionTemplateTypeArguments(
       continue;
 
     int argTypeId =
-        resolveTemplateArgumentTypeId(arg.getAsType(), typeProcessor, context);
+        templateProcessor->resolveTemplateArgumentTypeId(arg.getAsType());
     if (argTypeId == -1)
       continue;
 
@@ -356,15 +227,19 @@ void recordFunctionTemplateArgumentValues(
     int functionId, const clang::ASTTemplateArgumentListInfo *templateArgs,
     ExprProcessor *exprProcessor, TemplateProcessor *templateProcessor,
     clang::ASTContext *context) {
+  (void)exprProcessor;
+  (void)context;
+
   if (functionId == -1 || !templateArgs)
     return;
 
   for (unsigned index = 0; index < templateArgs->getNumTemplateArgs();
        ++index) {
     const clang::TemplateArgumentLoc &argLoc = (*templateArgs)[index];
-    const clang::Expr *sourceExpr = getTemplateArgumentSourceExpr(argLoc);
+    const clang::Expr *sourceExpr =
+        templateProcessor->getTemplateArgumentSourceExpr(argLoc);
     int exprId =
-        resolveTemplateArgumentExprId(sourceExpr, exprProcessor, context);
+        templateProcessor->resolveTemplateArgumentExprId(sourceExpr);
     if (exprId == -1)
       continue;
 
@@ -382,14 +257,18 @@ void recordFunctionTemplateArgumentValues(
     int functionId, const clang::TemplateArgumentLoc *templateArgs,
     unsigned numTemplateArgs, ExprProcessor *exprProcessor,
     TemplateProcessor *templateProcessor, clang::ASTContext *context) {
+  (void)exprProcessor;
+  (void)context;
+
   if (functionId == -1 || !templateArgs)
     return;
 
   for (unsigned index = 0; index < numTemplateArgs; ++index) {
     const clang::TemplateArgumentLoc &argLoc = templateArgs[index];
-    const clang::Expr *sourceExpr = getTemplateArgumentSourceExpr(argLoc);
+    const clang::Expr *sourceExpr =
+        templateProcessor->getTemplateArgumentSourceExpr(argLoc);
     int exprId =
-        resolveTemplateArgumentExprId(sourceExpr, exprProcessor, context);
+        templateProcessor->resolveTemplateArgumentExprId(sourceExpr);
     if (exprId == -1)
       continue;
 
@@ -407,6 +286,9 @@ void recordVariableTemplateTypeArguments(
     int variableId, const clang::TemplateArgumentList &templateArgs,
     TypeProcessor *typeProcessor, TemplateProcessor *templateProcessor,
     clang::ASTContext *context) {
+  (void)typeProcessor;
+  (void)context;
+
   if (variableId == -1)
     return;
 
@@ -416,7 +298,7 @@ void recordVariableTemplateTypeArguments(
       continue;
 
     int argTypeId =
-        resolveTemplateArgumentTypeId(arg.getAsType(), typeProcessor, context);
+        templateProcessor->resolveTemplateArgumentTypeId(arg.getAsType());
     if (argTypeId == -1)
       continue;
 
@@ -434,15 +316,19 @@ void recordVariableTemplateArgumentValues(
     int variableId, const clang::ASTTemplateArgumentListInfo *templateArgs,
     ExprProcessor *exprProcessor, TemplateProcessor *templateProcessor,
     clang::ASTContext *context) {
+  (void)exprProcessor;
+  (void)context;
+
   if (variableId == -1 || !templateArgs)
     return;
 
   for (unsigned index = 0; index < templateArgs->getNumTemplateArgs();
        ++index) {
     const clang::TemplateArgumentLoc &argLoc = (*templateArgs)[index];
-    const clang::Expr *sourceExpr = getTemplateArgumentSourceExpr(argLoc);
+    const clang::Expr *sourceExpr =
+        templateProcessor->getTemplateArgumentSourceExpr(argLoc);
     int exprId =
-        resolveTemplateArgumentExprId(sourceExpr, exprProcessor, context);
+        templateProcessor->resolveTemplateArgumentExprId(sourceExpr);
     if (exprId == -1)
       continue;
 
@@ -460,6 +346,9 @@ void recordConceptTemplateTypeArguments(
     int conceptId, llvm::ArrayRef<clang::TemplateArgument> templateArgs,
     TypeProcessor *typeProcessor, TemplateProcessor *templateProcessor,
     clang::ASTContext *context) {
+  (void)typeProcessor;
+  (void)context;
+
   if (conceptId == -1)
     return;
 
@@ -469,7 +358,7 @@ void recordConceptTemplateTypeArguments(
       continue;
 
     int argTypeId =
-        resolveTemplateArgumentTypeId(arg.getAsType(), typeProcessor, context);
+        templateProcessor->resolveTemplateArgumentTypeId(arg.getAsType());
     if (argTypeId == -1)
       continue;
 
@@ -503,7 +392,7 @@ void recordConceptTemplateArgumentValues(
     // Prefer source expression from args-as-written (with location info)
     if (argsAsWritten && index < argsAsWritten->getNumTemplateArgs()) {
       const clang::TemplateArgumentLoc &argLoc = (*argsAsWritten)[index];
-      sourceExpr = getTemplateArgumentSourceExpr(argLoc);
+      sourceExpr = templateProcessor->getTemplateArgumentSourceExpr(argLoc);
     }
 
     // Fall back: Expression kind directly stores the source expr
@@ -521,7 +410,7 @@ void recordConceptTemplateArgumentValues(
       continue;
 
     int exprId =
-        resolveTemplateArgumentExprId(sourceExpr, exprProcessor, context);
+        templateProcessor->resolveTemplateArgumentExprId(sourceExpr);
     if (exprId == -1)
       continue;
 
@@ -716,17 +605,15 @@ bool ASTVisitor::VisitVarDecl(clang::VarDecl *decl) {
   if (const auto *specialization =
           llvm::dyn_cast_or_null<clang::VarTemplateSpecializationDecl>(decl)) {
     int variableId =
-        resolveVariableEntityId(specialization, variable_processor_.get(),
-                                context_);
+        template_processor_->resolveVariableEntityId(specialization);
     if (variableId == -1)
       return true;
 
     const clang::VarTemplateDecl *primaryTemplate =
         specialization->getSpecializedTemplate();
     if (primaryTemplate && primaryTemplate->getTemplatedDecl()) {
-      int templateId = resolveVariableEntityId(
-          primaryTemplate->getTemplatedDecl(), variable_processor_.get(),
-          context_);
+      int templateId = template_processor_->resolveVariableEntityId(
+          primaryTemplate->getTemplatedDecl());
       if (templateId != -1 &&
           template_processor_->shouldInsertVariableInstantiation(variableId,
                                                                  templateId)) {
@@ -1094,9 +981,7 @@ bool ASTVisitor::VisitVarTemplateDecl(clang::VarTemplateDecl *decl) {
   if (!templatedDecl)
     return true;
 
-  int variableId =
-      resolveVariableEntityId(templatedDecl, variable_processor_.get(),
-                              context_);
+  int variableId = template_processor_->resolveVariableEntityId(templatedDecl);
   if (variableId == -1 ||
       !template_processor_->shouldInsertVariableTemplate(variableId))
     return true;

--- a/src/core/ast_visitor.cc
+++ b/src/core/ast_visitor.cc
@@ -28,451 +28,6 @@
 #include <unordered_map>
 #include <unordered_set>
 
-namespace {
-
-void recordClassTemplateTypeArguments(
-    int typeId, const clang::TemplateArgumentList &templateArgs,
-    TypeProcessor *typeProcessor, TemplateProcessor *templateProcessor,
-    clang::ASTContext *context) {
-  (void)typeProcessor;
-  (void)context;
-
-  if (typeId == -1)
-    return;
-
-  for (unsigned index = 0; index < templateArgs.size(); ++index) {
-    const clang::TemplateArgument &arg = templateArgs[index];
-    if (arg.getKind() != clang::TemplateArgument::Type)
-      continue;
-
-    int argTypeId =
-        templateProcessor->resolveTemplateArgumentTypeId(arg.getAsType());
-    if (argTypeId == -1)
-      continue;
-
-    if (!templateProcessor->shouldInsertClassTemplateArgument(
-            typeId, static_cast<int>(index), argTypeId))
-      continue;
-
-    DbModel::ClassTemplateArgument templateArgument = {
-        typeId, static_cast<int>(index), argTypeId};
-    STG.insertClassObj(templateArgument);
-  }
-}
-
-void recordClassTemplateArgumentValues(
-    int typeId, const clang::ASTTemplateArgumentListInfo *templateArgs,
-    ExprProcessor *exprProcessor, TemplateProcessor *templateProcessor,
-    clang::ASTContext *context) {
-  (void)exprProcessor;
-  (void)context;
-
-  if (typeId == -1 || !templateArgs)
-    return;
-
-  for (unsigned index = 0; index < templateArgs->getNumTemplateArgs();
-       ++index) {
-    const clang::TemplateArgumentLoc &argLoc = (*templateArgs)[index];
-    const clang::Expr *sourceExpr =
-        templateProcessor->getTemplateArgumentSourceExpr(argLoc);
-    int exprId =
-        templateProcessor->resolveTemplateArgumentExprId(sourceExpr);
-    if (exprId == -1)
-      continue;
-
-    if (!templateProcessor->shouldInsertClassTemplateArgumentValue(
-            typeId, static_cast<int>(index), exprId))
-      continue;
-
-    DbModel::ClassTemplateArgumentValue templateArgumentValue = {
-        typeId, static_cast<int>(index), exprId};
-    STG.insertClassObj(templateArgumentValue);
-  }
-}
-
-void recordClassTemplateArgumentValues(
-    int typeId, clang::TemplateSpecializationTypeLoc templateArgs,
-    ExprProcessor *exprProcessor, TemplateProcessor *templateProcessor,
-    clang::ASTContext *context) {
-  (void)exprProcessor;
-  (void)context;
-
-  if (typeId == -1 || !templateArgs)
-    return;
-
-  for (unsigned index = 0; index < templateArgs.getNumArgs(); ++index) {
-    const clang::TemplateArgumentLoc &argLoc = templateArgs.getArgLoc(index);
-    const clang::Expr *sourceExpr =
-        templateProcessor->getTemplateArgumentSourceExpr(argLoc);
-    int exprId =
-        templateProcessor->resolveTemplateArgumentExprId(sourceExpr);
-    if (exprId == -1)
-      continue;
-
-    if (!templateProcessor->shouldInsertClassTemplateArgumentValue(
-            typeId, static_cast<int>(index), exprId))
-      continue;
-
-    DbModel::ClassTemplateArgumentValue templateArgumentValue = {
-        typeId, static_cast<int>(index), exprId};
-    STG.insertClassObj(templateArgumentValue);
-  }
-}
-
-void recordTemplateTemplateArguments(
-    int typeId, const clang::TemplateArgumentList &templateArgs,
-    TypeProcessor *typeProcessor, TemplateProcessor *templateProcessor,
-    clang::ASTContext *context) {
-  (void)typeProcessor;
-  (void)context;
-
-  if (typeId == -1)
-    return;
-
-  for (unsigned index = 0; index < templateArgs.size(); ++index) {
-    const clang::TemplateArgument &arg = templateArgs[index];
-    int argTypeId =
-        templateProcessor->resolveTemplateTemplateArgumentTypeId(arg);
-    if (argTypeId == -1)
-      continue;
-
-    if (!templateProcessor->shouldInsertTemplateTemplateArgument(
-            typeId, static_cast<int>(index), argTypeId))
-      continue;
-
-    DbModel::TemplateTemplateArgument templateArgument = {
-        typeId, static_cast<int>(index), argTypeId};
-    STG.insertClassObj(templateArgument);
-  }
-}
-
-void recordTemplateTemplateInstantiations(
-    const clang::ClassTemplateDecl *classTemplateDecl,
-    const clang::TemplateArgumentList &templateArgs,
-    TypeProcessor *typeProcessor, TemplateProcessor *templateProcessor,
-    clang::ASTContext *context) {
-  if (!classTemplateDecl || !typeProcessor || !context)
-    return;
-
-  const clang::TemplateParameterList *params =
-      classTemplateDecl->getTemplateParameters();
-  if (!params)
-    return;
-
-  unsigned count = templateArgs.size();
-  if (params->size() < count)
-    count = params->size();
-
-  for (unsigned index = 0; index < count; ++index) {
-    const auto *param = llvm::dyn_cast_or_null<clang::TemplateTemplateParmDecl>(
-        params->getParam(index));
-    if (!param || param->isParameterPack())
-      continue;
-
-    const clang::TemplateArgument &arg = templateArgs[index];
-    const clang::TemplateDecl *templateDecl =
-        arg.getKind() == clang::TemplateArgument::Template
-            ? arg.getAsTemplate().getAsTemplateDecl()
-            : nullptr;
-    if (!llvm::isa_and_nonnull<clang::ClassTemplateDecl>(templateDecl))
-      continue;
-
-    int paramId = templateProcessor->resolveTemplateTemplateParmId(param);
-    int argTypeId =
-        templateProcessor->resolveTemplateTemplateArgumentTypeId(arg);
-    if (paramId == -1 || argTypeId == -1)
-      continue;
-
-    if (!templateProcessor->shouldInsertTemplateTemplateInstantiation(argTypeId,
-                                                                      paramId))
-      continue;
-
-    DbModel::TemplateTemplateInstantiation instantiation = {argTypeId,
-                                                            paramId};
-    STG.insertClassObj(instantiation);
-  }
-}
-
-void recordFunctionTemplateTypeArguments(
-    int functionId, const clang::TemplateArgumentList *templateArgs,
-    TypeProcessor *typeProcessor, TemplateProcessor *templateProcessor,
-    clang::ASTContext *context) {
-  (void)typeProcessor;
-  (void)context;
-
-  if (functionId == -1 || !templateArgs)
-    return;
-
-  for (unsigned index = 0; index < templateArgs->size(); ++index) {
-    const clang::TemplateArgument &arg = templateArgs->get(index);
-    if (arg.getKind() != clang::TemplateArgument::Type)
-      continue;
-
-    int argTypeId =
-        templateProcessor->resolveTemplateArgumentTypeId(arg.getAsType());
-    if (argTypeId == -1)
-      continue;
-
-    if (!templateProcessor->shouldInsertFunctionTemplateArgument(
-            functionId, static_cast<int>(index), argTypeId))
-      continue;
-
-    DbModel::FunctionTemplateArgument templateArgument = {
-        functionId, static_cast<int>(index), argTypeId};
-    STG.insertClassObj(templateArgument);
-  }
-}
-
-void recordFunctionTemplateArgumentValues(
-    int functionId, const clang::ASTTemplateArgumentListInfo *templateArgs,
-    ExprProcessor *exprProcessor, TemplateProcessor *templateProcessor,
-    clang::ASTContext *context) {
-  (void)exprProcessor;
-  (void)context;
-
-  if (functionId == -1 || !templateArgs)
-    return;
-
-  for (unsigned index = 0; index < templateArgs->getNumTemplateArgs();
-       ++index) {
-    const clang::TemplateArgumentLoc &argLoc = (*templateArgs)[index];
-    const clang::Expr *sourceExpr =
-        templateProcessor->getTemplateArgumentSourceExpr(argLoc);
-    int exprId =
-        templateProcessor->resolveTemplateArgumentExprId(sourceExpr);
-    if (exprId == -1)
-      continue;
-
-    if (!templateProcessor->shouldInsertFunctionTemplateArgumentValue(
-            functionId, static_cast<int>(index), exprId))
-      continue;
-
-    DbModel::FunctionTemplateArgumentValue templateArgumentValue = {
-        functionId, static_cast<int>(index), exprId};
-    STG.insertClassObj(templateArgumentValue);
-  }
-}
-
-void recordFunctionTemplateArgumentValues(
-    int functionId, const clang::TemplateArgumentLoc *templateArgs,
-    unsigned numTemplateArgs, ExprProcessor *exprProcessor,
-    TemplateProcessor *templateProcessor, clang::ASTContext *context) {
-  (void)exprProcessor;
-  (void)context;
-
-  if (functionId == -1 || !templateArgs)
-    return;
-
-  for (unsigned index = 0; index < numTemplateArgs; ++index) {
-    const clang::TemplateArgumentLoc &argLoc = templateArgs[index];
-    const clang::Expr *sourceExpr =
-        templateProcessor->getTemplateArgumentSourceExpr(argLoc);
-    int exprId =
-        templateProcessor->resolveTemplateArgumentExprId(sourceExpr);
-    if (exprId == -1)
-      continue;
-
-    if (!templateProcessor->shouldInsertFunctionTemplateArgumentValue(
-            functionId, static_cast<int>(index), exprId))
-      continue;
-
-    DbModel::FunctionTemplateArgumentValue templateArgumentValue = {
-        functionId, static_cast<int>(index), exprId};
-    STG.insertClassObj(templateArgumentValue);
-  }
-}
-
-void recordVariableTemplateTypeArguments(
-    int variableId, const clang::TemplateArgumentList &templateArgs,
-    TypeProcessor *typeProcessor, TemplateProcessor *templateProcessor,
-    clang::ASTContext *context) {
-  (void)typeProcessor;
-  (void)context;
-
-  if (variableId == -1)
-    return;
-
-  for (unsigned index = 0; index < templateArgs.size(); ++index) {
-    const clang::TemplateArgument &arg = templateArgs[index];
-    if (arg.getKind() != clang::TemplateArgument::Type)
-      continue;
-
-    int argTypeId =
-        templateProcessor->resolveTemplateArgumentTypeId(arg.getAsType());
-    if (argTypeId == -1)
-      continue;
-
-    if (!templateProcessor->shouldInsertVariableTemplateArgument(
-            variableId, static_cast<int>(index), argTypeId))
-      continue;
-
-    DbModel::VariableTemplateArgument templateArgument = {
-        variableId, static_cast<int>(index), argTypeId};
-    STG.insertClassObj(templateArgument);
-  }
-}
-
-void recordVariableTemplateArgumentValues(
-    int variableId, const clang::ASTTemplateArgumentListInfo *templateArgs,
-    ExprProcessor *exprProcessor, TemplateProcessor *templateProcessor,
-    clang::ASTContext *context) {
-  (void)exprProcessor;
-  (void)context;
-
-  if (variableId == -1 || !templateArgs)
-    return;
-
-  for (unsigned index = 0; index < templateArgs->getNumTemplateArgs();
-       ++index) {
-    const clang::TemplateArgumentLoc &argLoc = (*templateArgs)[index];
-    const clang::Expr *sourceExpr =
-        templateProcessor->getTemplateArgumentSourceExpr(argLoc);
-    int exprId =
-        templateProcessor->resolveTemplateArgumentExprId(sourceExpr);
-    if (exprId == -1)
-      continue;
-
-    if (!templateProcessor->shouldInsertVariableTemplateArgumentValue(
-            variableId, static_cast<int>(index), exprId))
-      continue;
-
-    DbModel::VariableTemplateArgumentValue templateArgumentValue = {
-        variableId, static_cast<int>(index), exprId};
-    STG.insertClassObj(templateArgumentValue);
-  }
-}
-
-void recordConceptTemplateTypeArguments(
-    int conceptId, llvm::ArrayRef<clang::TemplateArgument> templateArgs,
-    TypeProcessor *typeProcessor, TemplateProcessor *templateProcessor,
-    clang::ASTContext *context) {
-  (void)typeProcessor;
-  (void)context;
-
-  if (conceptId == -1)
-    return;
-
-  for (unsigned index = 0; index < templateArgs.size(); ++index) {
-    const clang::TemplateArgument &arg = templateArgs[index];
-    if (arg.getKind() != clang::TemplateArgument::Type)
-      continue;
-
-    int argTypeId =
-        templateProcessor->resolveTemplateArgumentTypeId(arg.getAsType());
-    if (argTypeId == -1)
-      continue;
-
-    if (!templateProcessor->shouldInsertConceptTemplateArgument(
-            conceptId, static_cast<int>(index), argTypeId))
-      continue;
-
-    DbModel::ConceptTemplateArgument templateArgument = {
-        conceptId, static_cast<int>(index), argTypeId};
-    STG.insertClassObj(templateArgument);
-  }
-}
-
-void recordConceptTemplateArgumentValues(
-    int conceptId, const clang::ConceptSpecializationExpr *expr,
-    ExprProcessor *exprProcessor, TemplateProcessor *templateProcessor,
-    clang::ASTContext *context) {
-  if (conceptId == -1 || !expr || !exprProcessor || !context)
-    return;
-
-  llvm::ArrayRef<clang::TemplateArgument> templateArgs =
-      expr->getTemplateArguments();
-
-  const clang::ASTTemplateArgumentListInfo *argsAsWritten =
-      expr->getTemplateArgsAsWritten();
-
-  for (unsigned index = 0; index < templateArgs.size(); ++index) {
-    const clang::TemplateArgument &arg = templateArgs[index];
-    const clang::Expr *sourceExpr = nullptr;
-
-    // Prefer source expression from args-as-written (with location info)
-    if (argsAsWritten && index < argsAsWritten->getNumTemplateArgs()) {
-      const clang::TemplateArgumentLoc &argLoc = (*argsAsWritten)[index];
-      sourceExpr = templateProcessor->getTemplateArgumentSourceExpr(argLoc);
-    }
-
-    // Fall back: Expression kind directly stores the source expr
-    if (!sourceExpr && arg.getKind() == clang::TemplateArgument::Expression) {
-      sourceExpr = arg.getAsExpr();
-    }
-
-    // Defer: no source expression available (e.g., Integral without source loc,
-    // SubstNonTypeTemplateParmExpr, dependent, pack, null, etc.)
-    if (!sourceExpr)
-      continue;
-
-    // Check for SubstNonTypeTemplateParmExpr — defer
-    if (llvm::isa<clang::SubstNonTypeTemplateParmExpr>(sourceExpr))
-      continue;
-
-    int exprId =
-        templateProcessor->resolveTemplateArgumentExprId(sourceExpr);
-    if (exprId == -1)
-      continue;
-
-    if (!templateProcessor->shouldInsertConceptTemplateArgumentValue(
-            conceptId, static_cast<int>(index), exprId))
-      continue;
-
-    DbModel::ConceptTemplateArgumentValue row = {conceptId,
-                                                  static_cast<int>(index),
-                                                  exprId};
-    STG.insertClassObj(row);
-  }
-}
-
-void recordTemplateTypeConstraint(const clang::TemplateTypeParmDecl *decl,
-                                  ExprProcessor *exprProcessor,
-                                  TemplateProcessor *templateProcessor,
-                                  clang::ASTContext *context) {
-  if (!decl || !exprProcessor || !context)
-    return;
-
-  const clang::TypeConstraint *typeConstraint = decl->getTypeConstraint();
-  if (!typeConstraint)
-    return;
-
-  const clang::Expr *constraintExpr =
-      typeConstraint->getImmediatelyDeclaredConstraint();
-  const auto *conceptExpr =
-      llvm::dyn_cast_or_null<clang::ConceptSpecializationExpr>(constraintExpr);
-  if (!conceptExpr)
-    return;
-
-  KeyType templateParamKey = KeyGen::Type::makeKey(decl, context);
-  int templateParamId = SEARCH_TYPE_CACHE(templateParamKey).value_or(-1);
-  if (templateParamId == -1)
-    return;
-
-  int conceptId = templateProcessor->resolveConceptSpecializationId(conceptExpr,
-                                                                    context);
-  if (conceptId == -1)
-    return;
-
-  int constraintExprId =
-      exprProcessor->processConceptSpecializationExpr(conceptExpr, conceptId);
-  if (constraintExprId == -1)
-    return;
-
-  if (templateProcessor->shouldInsertTypeTemplateTypeConstraint(
-          templateParamId, constraintExprId)) {
-    DbModel::TypeTemplateTypeConstraint row = {templateParamId,
-                                               constraintExprId};
-    STG.insertClassObj(row);
-  }
-
-  if (templateProcessor->shouldInsertIsTypeConstraint(conceptId)) {
-    DbModel::IsTypeConstraint row = {conceptId};
-    STG.insertClassObj(row);
-  }
-}
-
-} // namespace
-
 ASTVisitor::ASTVisitor(clang::ASTContext *context)
     : context_(context), pp_(context->getPrintingPolicy()) {
   initProcessors();
@@ -554,12 +109,10 @@ bool ASTVisitor::VisitFunctionDecl(clang::FunctionDecl *decl) {
       }
     }
 
-    recordFunctionTemplateTypeArguments(
-        specializationId, decl->getTemplateSpecializationArgs(),
-        type_processor_.get(), template_processor_.get(), context_);
-    recordFunctionTemplateArgumentValues(
-        specializationId, decl->getTemplateSpecializationArgsAsWritten(),
-        expr_processor_.get(), template_processor_.get(), context_);
+    template_processor_->recordFunctionTemplateTypeArguments(
+        specializationId, decl->getTemplateSpecializationArgs());
+    template_processor_->recordFunctionTemplateArgumentValues(
+        specializationId, decl->getTemplateSpecializationArgsAsWritten());
   }
 
   return true;
@@ -597,9 +150,8 @@ bool ASTVisitor::VisitVarDecl(clang::VarDecl *decl) {
   if (clang::TypeSourceInfo *typeInfo = decl->getTypeSourceInfo()) {
     auto templateTypeLoc = typeInfo->getTypeLoc()
                                .getAsAdjusted<clang::TemplateSpecializationTypeLoc>();
-    recordClassTemplateArgumentValues(type_id, templateTypeLoc,
-                                      expr_processor_.get(),
-                                      template_processor_.get(), context_);
+    template_processor_->recordClassTemplateArgumentValues(type_id,
+                                                           templateTypeLoc);
   }
 
   if (const auto *specialization =
@@ -623,12 +175,10 @@ bool ASTVisitor::VisitVarDecl(clang::VarDecl *decl) {
       }
     }
 
-    recordVariableTemplateTypeArguments(
-        variableId, specialization->getTemplateInstantiationArgs(),
-        type_processor_.get(), template_processor_.get(), context_);
-    recordVariableTemplateArgumentValues(
-        variableId, specialization->getTemplateArgsAsWritten(),
-        expr_processor_.get(), template_processor_.get(), context_);
+    template_processor_->recordVariableTemplateTypeArguments(
+        variableId, specialization->getTemplateInstantiationArgs());
+    template_processor_->recordVariableTemplateArgumentValues(
+        variableId, specialization->getTemplateArgsAsWritten());
   }
   return true;
 }
@@ -683,8 +233,7 @@ bool ASTVisitor::VisitTypedefDecl(clang::TypedefDecl *decl) {
 
 bool ASTVisitor::VisitTemplateTypeParmDecl(clang::TemplateTypeParmDecl *decl) {
   type_processor_->processTemplateTypeParmDecl(decl);
-  recordTemplateTypeConstraint(decl, expr_processor_.get(),
-                               template_processor_.get(), context_);
+  template_processor_->recordTemplateTypeConstraint(decl);
   return true;
 }
 
@@ -933,18 +482,14 @@ bool ASTVisitor::VisitClassTemplateSpecializationDecl(
     }
   }
 
-  recordClassTemplateTypeArguments(
-      specializationId, decl->getTemplateInstantiationArgs(),
-      type_processor_.get(), template_processor_.get(), context_);
-  recordTemplateTemplateArguments(
-      specializationId, decl->getTemplateInstantiationArgs(),
-      type_processor_.get(), template_processor_.get(), context_);
-  recordTemplateTemplateInstantiations(
-      classTemplateDecl, decl->getTemplateInstantiationArgs(),
-      type_processor_.get(), template_processor_.get(), context_);
-  recordClassTemplateArgumentValues(
-      specializationId, decl->getTemplateArgsAsWritten(), expr_processor_.get(),
-      template_processor_.get(), context_);
+  template_processor_->recordClassTemplateTypeArguments(
+      specializationId, decl->getTemplateInstantiationArgs());
+  template_processor_->recordTemplateTemplateArguments(
+      specializationId, decl->getTemplateInstantiationArgs());
+  template_processor_->recordTemplateTemplateInstantiations(
+      classTemplateDecl, decl->getTemplateInstantiationArgs());
+  template_processor_->recordClassTemplateArgumentValues(
+      specializationId, decl->getTemplateArgsAsWritten());
 
   return true;
 }
@@ -1002,9 +547,8 @@ bool ASTVisitor::VisitDeclRefExpr(clang::DeclRefExpr *expr) {
             llvm::dyn_cast<clang::FunctionDecl>(expr->getDecl())) {
       KeyType functionKey = KeyGen::Function::makeKey(functionDecl, context_);
       int functionId = SEARCH_FUNCTION_CACHE(functionKey).value_or(-1);
-      recordFunctionTemplateArgumentValues(
-          functionId, expr->getTemplateArgs(), expr->getNumTemplateArgs(),
-          expr_processor_.get(), template_processor_.get(), context_);
+      template_processor_->recordFunctionTemplateArgumentValues(
+          functionId, expr->getTemplateArgs(), expr->getNumTemplateArgs());
     }
   }
 
@@ -1099,10 +643,8 @@ bool ASTVisitor::VisitConceptSpecializationExpr(
     STG.insertClassObj(instantiation);
   }
 
-  recordConceptTemplateTypeArguments(conceptId, expr->getTemplateArguments(),
-                                     type_processor_.get(),
-                                     template_processor_.get(), context_);
-  recordConceptTemplateArgumentValues(conceptId, expr, expr_processor_.get(),
-                                      template_processor_.get(), context_);
+  template_processor_->recordConceptTemplateTypeArguments(
+      conceptId, expr->getTemplateArguments());
+  template_processor_->recordConceptTemplateArgumentValues(conceptId, expr);
   return true;
 }

--- a/src/core/processor/template_processor.cc
+++ b/src/core/processor/template_processor.cc
@@ -8,16 +8,20 @@
 #include "core/processor/type_processor.h"
 #include "core/processor/variable_processor.h"
 #include "core/srcloc_recorder.h"
+#include "db/dependency_manager.h"
 #include "db/storage_facade.h"
 #include "model/db/concept.h"
+#include "model/db/declaration.h"
 #include "model/db/function.h"
 #include "model/db/type.h"
 #include "model/db/variable.h"
 #include "util/id_generator.h"
 #include "util/key_generator/expr.h"
+#include "util/key_generator/function.h"
 #include "util/key_generator/type.h"
 #include "util/key_generator/variable.h"
 #include <clang/AST/ASTConcept.h>
+#include <clang/AST/DeclFriend.h>
 #include <clang/AST/DeclTemplate.h>
 #include <clang/AST/ExprConcepts.h>
 #include <clang/AST/TypeLoc.h>
@@ -784,4 +788,233 @@ void TemplateProcessor::recordTemplateTypeConstraint(
     DbModel::IsTypeConstraint row = {conceptId};
     STG.insertClassObj(row);
   }
+}
+
+void TemplateProcessor::processFunctionTemplateSpecialization(
+    const clang::FunctionDecl *decl, int functionId) {
+  if (decl && decl->isFunctionTemplateSpecialization()) {
+    KeyType functionKey = KeyGen::Function::makeKey(decl, ast_context_);
+    int specializationId = functionId;
+    if (auto cachedId = SEARCH_FUNCTION_CACHE(functionKey))
+      specializationId = *cachedId;
+    if (specializationId == -1)
+      return;
+
+    if (const clang::FunctionTemplateDecl *primaryTemplate =
+            decl->getPrimaryTemplate()) {
+      const clang::FunctionDecl *templatedDecl =
+          primaryTemplate->getTemplatedDecl();
+      KeyType templateKey = KeyGen::Function::makeKey(templatedDecl,
+                                                      ast_context_);
+
+      if (auto cachedId = SEARCH_FUNCTION_CACHE(templateKey)) {
+        if (this->shouldInsertFunctionInstantiation(
+                specializationId, *cachedId)) {
+          DbModel::FunctionInstantiation instantiation = {
+              specializationId, *cachedId};
+          STG.insertClassObj(instantiation);
+        }
+      } else {
+        PendingUpdate update{
+            templateKey, CacheType::FUNCTION,
+            [specializationId,
+             templateProcessor = this](int resolvedId) {
+              if (!templateProcessor->shouldInsertFunctionInstantiation(
+                      specializationId, resolvedId))
+                return;
+
+              DbModel::FunctionInstantiation instantiation = {
+                  specializationId, resolvedId};
+              STG.insertClassObj(instantiation);
+            }};
+        DependencyManager::instance().addDependency(update);
+      }
+    }
+
+    this->recordFunctionTemplateTypeArguments(
+        specializationId, decl->getTemplateSpecializationArgs());
+    this->recordFunctionTemplateArgumentValues(
+        specializationId, decl->getTemplateSpecializationArgsAsWritten());
+  }
+}
+
+void TemplateProcessor::processVarTemplateSpecialization(
+    const clang::VarTemplateSpecializationDecl *decl, int) {
+  if (const auto *specialization =
+          llvm::dyn_cast_or_null<clang::VarTemplateSpecializationDecl>(decl)) {
+    int variableId =
+        this->resolveVariableEntityId(specialization);
+    if (variableId == -1)
+      return;
+
+    const clang::VarTemplateDecl *primaryTemplate =
+        specialization->getSpecializedTemplate();
+    if (primaryTemplate && primaryTemplate->getTemplatedDecl()) {
+      int templateId = this->resolveVariableEntityId(
+          primaryTemplate->getTemplatedDecl());
+      if (templateId != -1 &&
+          this->shouldInsertVariableInstantiation(variableId,
+                                                  templateId)) {
+        DbModel::VariableInstantiation instantiation = {variableId,
+                                                        templateId};
+        STG.insertClassObj(instantiation);
+      }
+    }
+
+    this->recordVariableTemplateTypeArguments(
+        variableId, specialization->getTemplateInstantiationArgs());
+    this->recordVariableTemplateArgumentValues(
+        variableId, specialization->getTemplateArgsAsWritten());
+  }
+}
+
+void TemplateProcessor::processClassTemplateSpecialization(
+    const clang::ClassTemplateSpecializationDecl *decl) {
+  if (!decl)
+    return;
+
+  const clang::ClassTemplateDecl *classTemplateDecl = nullptr;
+  auto instantiatedFrom = decl->getInstantiatedFrom();
+  if (!instantiatedFrom.isNull())
+    classTemplateDecl = instantiatedFrom.dyn_cast<clang::ClassTemplateDecl *>();
+  if (!classTemplateDecl)
+    classTemplateDecl = decl->getSpecializedTemplate();
+  if (!classTemplateDecl)
+    return;
+
+  const clang::CXXRecordDecl *templatedDecl =
+      classTemplateDecl->getTemplatedDecl();
+  if (!templatedDecl)
+    return;
+
+  KeyType specializationKey = KeyGen::Type::makeKey(decl, ast_context_);
+  if (!SEARCH_TYPE_CACHE(specializationKey))
+    type_processor_->processRecordDeclType(decl);
+
+  KeyType templateKey = KeyGen::Type::makeKey(templatedDecl, ast_context_);
+  if (!SEARCH_TYPE_CACHE(templateKey))
+    type_processor_->processRecordDeclType(templatedDecl);
+
+  int specializationId = -1;
+  int templateId = -1;
+
+  if (auto cachedId = SEARCH_TYPE_CACHE(specializationKey))
+    specializationId = *cachedId;
+  if (auto cachedId = SEARCH_TYPE_CACHE(templateKey))
+    templateId = *cachedId;
+
+  if (specializationId != -1 && templateId != -1) {
+    if (this->shouldInsertClassInstantiation(specializationId,
+                                             templateId)) {
+      DbModel::ClassInstantiation instantiation = {specializationId,
+                                                   templateId};
+      STG.insertClassObj(instantiation);
+    }
+  }
+
+  this->recordClassTemplateTypeArguments(
+      specializationId, decl->getTemplateInstantiationArgs());
+  this->recordTemplateTemplateArguments(
+      specializationId, decl->getTemplateInstantiationArgs());
+  this->recordTemplateTemplateInstantiations(
+      classTemplateDecl, decl->getTemplateInstantiationArgs());
+  this->recordClassTemplateArgumentValues(
+      specializationId, decl->getTemplateArgsAsWritten());
+}
+
+void TemplateProcessor::processFriendDecl(const clang::FriendDecl *decl) {
+  if (!decl)
+    return;
+
+  LocIdPair *locIdPair = SrcLocRecorder::processDefault(decl, ast_context_);
+  const int friendDeclId = GENID(FriendDecl);
+  int typeId = -1;
+  int declId = -1;
+
+  auto resolveRecordType = [&](const clang::RecordType *recordType) -> int {
+    if (!recordType || !recordType->getDecl())
+      return -1;
+
+    type_processor_->processRecordType(recordType);
+    KeyType typeKey = KeyGen::Type::makeKey(recordType->getDecl(),
+                                            ast_context_);
+    if (auto cachedId = SEARCH_TYPE_CACHE(typeKey))
+      return *cachedId;
+
+    return -1;
+  };
+
+  auto resolveFriendType = [&](clang::QualType friendType) -> int {
+    if (friendType.isNull())
+      return -1;
+
+    if (const auto *recordType = friendType->getAs<clang::RecordType>())
+      return resolveRecordType(recordType);
+
+    return type_processor_->processType(friendType.getTypePtr());
+  };
+
+  if (clang::TypeSourceInfo *friendTypeInfo = decl->getFriendType()) {
+    typeId = resolveFriendType(friendTypeInfo->getType());
+  } else if (clang::NamedDecl *friendNamedDecl = decl->getFriendDecl()) {
+    if (const auto *functionDecl =
+            llvm::dyn_cast<clang::FunctionDecl>(friendNamedDecl)) {
+      KeyType functionKey = KeyGen::Function::makeKey(functionDecl,
+                                                      ast_context_);
+      if (auto cachedId = SEARCH_FUNCTION_CACHE(functionKey)) {
+        declId = *cachedId;
+      } else {
+        PendingUpdate update{
+            functionKey, CacheType::FUNCTION,
+            [friendDeclId, typeId, location = locIdPair->spec_id](
+                int resolvedId) {
+              DbModel::FriendDecl updatedRecord = {friendDeclId, typeId,
+                                                   resolvedId, location};
+              STG.insertClassObj(updatedRecord);
+            }};
+        DependencyManager::instance().addDependency(update);
+      }
+    } else if (const auto *typeDecl =
+                   llvm::dyn_cast<clang::TypeDecl>(friendNamedDecl)) {
+      if (const auto *recordDecl =
+              llvm::dyn_cast<clang::RecordDecl>(typeDecl)) {
+        if (const auto *recordType =
+                llvm::dyn_cast_or_null<clang::RecordType>(
+                    recordDecl->getTypeForDecl()))
+          typeId = resolveRecordType(recordType);
+      }
+    }
+  }
+
+  DbModel::FriendDecl friendDeclModel = {friendDeclId, typeId, declId,
+                                         locIdPair->spec_id};
+  STG.insertClassObj(friendDeclModel);
+}
+
+void TemplateProcessor::processConceptSpecialization(
+    const clang::ConceptSpecializationExpr *expr) {
+  if (!expr)
+    return;
+
+  int templateId = this->resolveConceptTemplateId(
+      expr->getNamedConcept(), ast_context_);
+  if (templateId == -1)
+    return;
+
+  int conceptId = this->resolveConceptSpecializationId(expr,
+                                                       ast_context_);
+  if (conceptId == -1)
+    return;
+
+  expr_processor_->processConceptSpecializationExpr(expr, conceptId);
+
+  if (this->shouldInsertConceptInstantiation(conceptId,
+                                             templateId)) {
+    DbModel::ConceptInstantiation instantiation = {conceptId, templateId};
+    STG.insertClassObj(instantiation);
+  }
+
+  this->recordConceptTemplateTypeArguments(
+      conceptId, expr->getTemplateArguments());
+  this->recordConceptTemplateArgumentValues(conceptId, expr);
 }

--- a/src/core/processor/template_processor.cc
+++ b/src/core/processor/template_processor.cc
@@ -10,6 +10,9 @@
 #include "core/srcloc_recorder.h"
 #include "db/storage_facade.h"
 #include "model/db/concept.h"
+#include "model/db/function.h"
+#include "model/db/type.h"
+#include "model/db/variable.h"
 #include "util/id_generator.h"
 #include "util/key_generator/expr.h"
 #include "util/key_generator/type.h"
@@ -17,6 +20,7 @@
 #include <clang/AST/ASTConcept.h>
 #include <clang/AST/DeclTemplate.h>
 #include <clang/AST/ExprConcepts.h>
+#include <clang/AST/TypeLoc.h>
 #include <clang/Basic/SourceManager.h>
 #include <cstdint>
 #include <llvm/Support/raw_ostream.h>
@@ -394,4 +398,390 @@ int TemplateProcessor::resolveTemplateArgumentExprId(
     return *cachedId;
 
   return -1;
+}
+
+void TemplateProcessor::recordClassTemplateTypeArguments(
+    int typeId, const clang::TemplateArgumentList &templateArgs) {
+  if (typeId == -1)
+    return;
+
+  for (unsigned index = 0; index < templateArgs.size(); ++index) {
+    const clang::TemplateArgument &arg = templateArgs[index];
+    if (arg.getKind() != clang::TemplateArgument::Type)
+      continue;
+
+    int argTypeId =
+        this->resolveTemplateArgumentTypeId(arg.getAsType());
+    if (argTypeId == -1)
+      continue;
+
+    if (!this->shouldInsertClassTemplateArgument(
+            typeId, static_cast<int>(index), argTypeId))
+      continue;
+
+    DbModel::ClassTemplateArgument templateArgument = {
+        typeId, static_cast<int>(index), argTypeId};
+    STG.insertClassObj(templateArgument);
+  }
+}
+
+void TemplateProcessor::recordClassTemplateArgumentValues(
+    int typeId, const clang::ASTTemplateArgumentListInfo *templateArgs) {
+  if (typeId == -1 || !templateArgs)
+    return;
+
+  for (unsigned index = 0; index < templateArgs->getNumTemplateArgs();
+       ++index) {
+    const clang::TemplateArgumentLoc &argLoc = (*templateArgs)[index];
+    const clang::Expr *sourceExpr =
+        this->getTemplateArgumentSourceExpr(argLoc);
+    int exprId =
+        this->resolveTemplateArgumentExprId(sourceExpr);
+    if (exprId == -1)
+      continue;
+
+    if (!this->shouldInsertClassTemplateArgumentValue(
+            typeId, static_cast<int>(index), exprId))
+      continue;
+
+    DbModel::ClassTemplateArgumentValue templateArgumentValue = {
+        typeId, static_cast<int>(index), exprId};
+    STG.insertClassObj(templateArgumentValue);
+  }
+}
+
+void TemplateProcessor::recordClassTemplateArgumentValues(
+    int typeId, clang::TemplateSpecializationTypeLoc templateArgs) {
+  if (typeId == -1 || !templateArgs)
+    return;
+
+  for (unsigned index = 0; index < templateArgs.getNumArgs(); ++index) {
+    const clang::TemplateArgumentLoc &argLoc = templateArgs.getArgLoc(index);
+    const clang::Expr *sourceExpr =
+        this->getTemplateArgumentSourceExpr(argLoc);
+    int exprId =
+        this->resolveTemplateArgumentExprId(sourceExpr);
+    if (exprId == -1)
+      continue;
+
+    if (!this->shouldInsertClassTemplateArgumentValue(
+            typeId, static_cast<int>(index), exprId))
+      continue;
+
+    DbModel::ClassTemplateArgumentValue templateArgumentValue = {
+        typeId, static_cast<int>(index), exprId};
+    STG.insertClassObj(templateArgumentValue);
+  }
+}
+
+void TemplateProcessor::recordTemplateTemplateArguments(
+    int typeId, const clang::TemplateArgumentList &templateArgs) {
+  if (typeId == -1)
+    return;
+
+  for (unsigned index = 0; index < templateArgs.size(); ++index) {
+    const clang::TemplateArgument &arg = templateArgs[index];
+    int argTypeId =
+        this->resolveTemplateTemplateArgumentTypeId(arg);
+    if (argTypeId == -1)
+      continue;
+
+    if (!this->shouldInsertTemplateTemplateArgument(
+            typeId, static_cast<int>(index), argTypeId))
+      continue;
+
+    DbModel::TemplateTemplateArgument templateArgument = {
+        typeId, static_cast<int>(index), argTypeId};
+    STG.insertClassObj(templateArgument);
+  }
+}
+
+void TemplateProcessor::recordTemplateTemplateInstantiations(
+    const clang::ClassTemplateDecl *classTemplateDecl,
+    const clang::TemplateArgumentList &templateArgs) {
+  if (!classTemplateDecl || !type_processor_ || !ast_context_)
+    return;
+
+  const clang::TemplateParameterList *params =
+      classTemplateDecl->getTemplateParameters();
+  if (!params)
+    return;
+
+  unsigned count = templateArgs.size();
+  if (params->size() < count)
+    count = params->size();
+
+  for (unsigned index = 0; index < count; ++index) {
+    const auto *param = llvm::dyn_cast_or_null<clang::TemplateTemplateParmDecl>(
+        params->getParam(index));
+    if (!param || param->isParameterPack())
+      continue;
+
+    const clang::TemplateArgument &arg = templateArgs[index];
+    const clang::TemplateDecl *templateDecl =
+        arg.getKind() == clang::TemplateArgument::Template
+            ? arg.getAsTemplate().getAsTemplateDecl()
+            : nullptr;
+    if (!llvm::isa_and_nonnull<clang::ClassTemplateDecl>(templateDecl))
+      continue;
+
+    int paramId = this->resolveTemplateTemplateParmId(param);
+    int argTypeId =
+        this->resolveTemplateTemplateArgumentTypeId(arg);
+    if (paramId == -1 || argTypeId == -1)
+      continue;
+
+    if (!this->shouldInsertTemplateTemplateInstantiation(argTypeId,
+                                                         paramId))
+      continue;
+
+    DbModel::TemplateTemplateInstantiation instantiation = {argTypeId,
+                                                            paramId};
+    STG.insertClassObj(instantiation);
+  }
+}
+
+void TemplateProcessor::recordFunctionTemplateTypeArguments(
+    int functionId, const clang::TemplateArgumentList *templateArgs) {
+  if (functionId == -1 || !templateArgs)
+    return;
+
+  for (unsigned index = 0; index < templateArgs->size(); ++index) {
+    const clang::TemplateArgument &arg = templateArgs->get(index);
+    if (arg.getKind() != clang::TemplateArgument::Type)
+      continue;
+
+    int argTypeId =
+        this->resolveTemplateArgumentTypeId(arg.getAsType());
+    if (argTypeId == -1)
+      continue;
+
+    if (!this->shouldInsertFunctionTemplateArgument(
+            functionId, static_cast<int>(index), argTypeId))
+      continue;
+
+    DbModel::FunctionTemplateArgument templateArgument = {
+        functionId, static_cast<int>(index), argTypeId};
+    STG.insertClassObj(templateArgument);
+  }
+}
+
+void TemplateProcessor::recordFunctionTemplateArgumentValues(
+    int functionId, const clang::ASTTemplateArgumentListInfo *templateArgs) {
+  if (functionId == -1 || !templateArgs)
+    return;
+
+  for (unsigned index = 0; index < templateArgs->getNumTemplateArgs();
+       ++index) {
+    const clang::TemplateArgumentLoc &argLoc = (*templateArgs)[index];
+    const clang::Expr *sourceExpr =
+        this->getTemplateArgumentSourceExpr(argLoc);
+    int exprId =
+        this->resolveTemplateArgumentExprId(sourceExpr);
+    if (exprId == -1)
+      continue;
+
+    if (!this->shouldInsertFunctionTemplateArgumentValue(
+            functionId, static_cast<int>(index), exprId))
+      continue;
+
+    DbModel::FunctionTemplateArgumentValue templateArgumentValue = {
+        functionId, static_cast<int>(index), exprId};
+    STG.insertClassObj(templateArgumentValue);
+  }
+}
+
+void TemplateProcessor::recordFunctionTemplateArgumentValues(
+    int functionId, const clang::TemplateArgumentLoc *templateArgs,
+    unsigned numTemplateArgs) {
+  if (functionId == -1 || !templateArgs)
+    return;
+
+  for (unsigned index = 0; index < numTemplateArgs; ++index) {
+    const clang::TemplateArgumentLoc &argLoc = templateArgs[index];
+    const clang::Expr *sourceExpr =
+        this->getTemplateArgumentSourceExpr(argLoc);
+    int exprId =
+        this->resolveTemplateArgumentExprId(sourceExpr);
+    if (exprId == -1)
+      continue;
+
+    if (!this->shouldInsertFunctionTemplateArgumentValue(
+            functionId, static_cast<int>(index), exprId))
+      continue;
+
+    DbModel::FunctionTemplateArgumentValue templateArgumentValue = {
+        functionId, static_cast<int>(index), exprId};
+    STG.insertClassObj(templateArgumentValue);
+  }
+}
+
+void TemplateProcessor::recordVariableTemplateTypeArguments(
+    int variableId, const clang::TemplateArgumentList &templateArgs) {
+  if (variableId == -1)
+    return;
+
+  for (unsigned index = 0; index < templateArgs.size(); ++index) {
+    const clang::TemplateArgument &arg = templateArgs[index];
+    if (arg.getKind() != clang::TemplateArgument::Type)
+      continue;
+
+    int argTypeId =
+        this->resolveTemplateArgumentTypeId(arg.getAsType());
+    if (argTypeId == -1)
+      continue;
+
+    if (!this->shouldInsertVariableTemplateArgument(
+            variableId, static_cast<int>(index), argTypeId))
+      continue;
+
+    DbModel::VariableTemplateArgument templateArgument = {
+        variableId, static_cast<int>(index), argTypeId};
+    STG.insertClassObj(templateArgument);
+  }
+}
+
+void TemplateProcessor::recordVariableTemplateArgumentValues(
+    int variableId, const clang::ASTTemplateArgumentListInfo *templateArgs) {
+  if (variableId == -1 || !templateArgs)
+    return;
+
+  for (unsigned index = 0; index < templateArgs->getNumTemplateArgs();
+       ++index) {
+    const clang::TemplateArgumentLoc &argLoc = (*templateArgs)[index];
+    const clang::Expr *sourceExpr =
+        this->getTemplateArgumentSourceExpr(argLoc);
+    int exprId =
+        this->resolveTemplateArgumentExprId(sourceExpr);
+    if (exprId == -1)
+      continue;
+
+    if (!this->shouldInsertVariableTemplateArgumentValue(
+            variableId, static_cast<int>(index), exprId))
+      continue;
+
+    DbModel::VariableTemplateArgumentValue templateArgumentValue = {
+        variableId, static_cast<int>(index), exprId};
+    STG.insertClassObj(templateArgumentValue);
+  }
+}
+
+void TemplateProcessor::recordConceptTemplateTypeArguments(
+    int conceptId, llvm::ArrayRef<clang::TemplateArgument> templateArgs) {
+  if (conceptId == -1)
+    return;
+
+  for (unsigned index = 0; index < templateArgs.size(); ++index) {
+    const clang::TemplateArgument &arg = templateArgs[index];
+    if (arg.getKind() != clang::TemplateArgument::Type)
+      continue;
+
+    int argTypeId =
+        this->resolveTemplateArgumentTypeId(arg.getAsType());
+    if (argTypeId == -1)
+      continue;
+
+    if (!this->shouldInsertConceptTemplateArgument(
+            conceptId, static_cast<int>(index), argTypeId))
+      continue;
+
+    DbModel::ConceptTemplateArgument templateArgument = {
+        conceptId, static_cast<int>(index), argTypeId};
+    STG.insertClassObj(templateArgument);
+  }
+}
+
+void TemplateProcessor::recordConceptTemplateArgumentValues(
+    int conceptId, const clang::ConceptSpecializationExpr *expr) {
+  if (conceptId == -1 || !expr || !expr_processor_ || !ast_context_)
+    return;
+
+  llvm::ArrayRef<clang::TemplateArgument> templateArgs =
+      expr->getTemplateArguments();
+
+  const clang::ASTTemplateArgumentListInfo *argsAsWritten =
+      expr->getTemplateArgsAsWritten();
+
+  for (unsigned index = 0; index < templateArgs.size(); ++index) {
+    const clang::TemplateArgument &arg = templateArgs[index];
+    const clang::Expr *sourceExpr = nullptr;
+
+    // Prefer source expression from args-as-written (with location info)
+    if (argsAsWritten && index < argsAsWritten->getNumTemplateArgs()) {
+      const clang::TemplateArgumentLoc &argLoc = (*argsAsWritten)[index];
+      sourceExpr = this->getTemplateArgumentSourceExpr(argLoc);
+    }
+
+    // Fall back: Expression kind directly stores the source expr
+    if (!sourceExpr && arg.getKind() == clang::TemplateArgument::Expression) {
+      sourceExpr = arg.getAsExpr();
+    }
+
+    // Defer: no source expression available (e.g., Integral without source loc,
+    // SubstNonTypeTemplateParmExpr, dependent, pack, null, etc.)
+    if (!sourceExpr)
+      continue;
+
+    // Check for SubstNonTypeTemplateParmExpr — defer
+    if (llvm::isa<clang::SubstNonTypeTemplateParmExpr>(sourceExpr))
+      continue;
+
+    int exprId =
+        this->resolveTemplateArgumentExprId(sourceExpr);
+    if (exprId == -1)
+      continue;
+
+    if (!this->shouldInsertConceptTemplateArgumentValue(
+            conceptId, static_cast<int>(index), exprId))
+      continue;
+
+    DbModel::ConceptTemplateArgumentValue row = {conceptId,
+                                                  static_cast<int>(index),
+                                                  exprId};
+    STG.insertClassObj(row);
+  }
+}
+
+void TemplateProcessor::recordTemplateTypeConstraint(
+    const clang::TemplateTypeParmDecl *decl) {
+  if (!decl || !expr_processor_ || !ast_context_)
+    return;
+
+  const clang::TypeConstraint *typeConstraint = decl->getTypeConstraint();
+  if (!typeConstraint)
+    return;
+
+  const clang::Expr *constraintExpr =
+      typeConstraint->getImmediatelyDeclaredConstraint();
+  const auto *conceptExpr =
+      llvm::dyn_cast_or_null<clang::ConceptSpecializationExpr>(constraintExpr);
+  if (!conceptExpr)
+    return;
+
+  KeyType templateParamKey = KeyGen::Type::makeKey(decl, ast_context_);
+  int templateParamId = SEARCH_TYPE_CACHE(templateParamKey).value_or(-1);
+  if (templateParamId == -1)
+    return;
+
+  int conceptId = this->resolveConceptSpecializationId(conceptExpr,
+                                                       ast_context_);
+  if (conceptId == -1)
+    return;
+
+  int constraintExprId =
+      expr_processor_->processConceptSpecializationExpr(conceptExpr, conceptId);
+  if (constraintExprId == -1)
+    return;
+
+  if (this->shouldInsertTypeTemplateTypeConstraint(
+          templateParamId, constraintExprId)) {
+    DbModel::TypeTemplateTypeConstraint row = {templateParamId,
+                                               constraintExprId};
+    STG.insertClassObj(row);
+  }
+
+  if (this->shouldInsertIsTypeConstraint(conceptId)) {
+    DbModel::IsTypeConstraint row = {conceptId};
+    STG.insertClassObj(row);
+  }
 }

--- a/src/core/processor/template_processor.cc
+++ b/src/core/processor/template_processor.cc
@@ -1,0 +1,252 @@
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#endif
+
+#include "core/processor/template_processor.h"
+#include "core/srcloc_recorder.h"
+#include "db/storage_facade.h"
+#include "model/db/concept.h"
+#include "util/id_generator.h"
+#include "util/key_generator/type.h"
+#include <clang/AST/ASTConcept.h>
+#include <clang/AST/DeclTemplate.h>
+#include <clang/AST/ExprConcepts.h>
+#include <clang/Basic/SourceManager.h>
+#include <cstdint>
+#include <llvm/Support/raw_ostream.h>
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+namespace {
+
+struct ConceptSpecializationId {
+  int id;
+};
+
+} // namespace
+
+std::string TemplateProcessor::makePairKey(int first, int second) {
+  return std::to_string(first) + ":" + std::to_string(second);
+}
+
+std::string TemplateProcessor::makeTripleKey(int first, int second,
+                                             int third) {
+  return std::to_string(first) + ":" + std::to_string(second) + ":" +
+         std::to_string(third);
+}
+
+bool TemplateProcessor::shouldInsertClassInstantiation(int to, int from) {
+  return classInstantiationDedup.insert(makePairKey(to, from)).second;
+}
+
+bool TemplateProcessor::shouldInsertClassTemplateArgument(int typeId, int index,
+                                                          int argType) {
+  return classTemplateArgumentDedup
+      .insert(makeTripleKey(typeId, index, argType))
+      .second;
+}
+
+bool TemplateProcessor::shouldInsertClassTemplateArgumentValue(int typeId,
+                                                               int index,
+                                                               int argValue) {
+  return classTemplateArgumentValueDedup
+      .insert(makeTripleKey(typeId, index, argValue))
+      .second;
+}
+
+bool TemplateProcessor::shouldInsertFunctionInstantiation(int to, int from) {
+  return functionInstantiationDedup.insert(makePairKey(to, from)).second;
+}
+
+bool TemplateProcessor::shouldInsertFunctionTemplateArgument(int functionId,
+                                                             int index,
+                                                             int argType) {
+  return functionTemplateArgumentDedup
+      .insert(makeTripleKey(functionId, index, argType))
+      .second;
+}
+
+bool TemplateProcessor::shouldInsertFunctionTemplateArgumentValue(
+    int functionId, int index, int argValue) {
+  return functionTemplateArgumentValueDedup
+      .insert(makeTripleKey(functionId, index, argValue))
+      .second;
+}
+
+bool TemplateProcessor::shouldInsertVariableTemplate(int variableId) {
+  return variableTemplateDedup.insert(std::to_string(variableId)).second;
+}
+
+bool TemplateProcessor::shouldInsertVariableInstantiation(int to, int from) {
+  return variableInstantiationDedup
+      .insert(makePairKey(to, from))
+      .second;
+}
+
+bool TemplateProcessor::shouldInsertVariableTemplateArgument(int variableId,
+                                                             int index,
+                                                             int argType) {
+  return variableTemplateArgumentDedup
+      .insert(makeTripleKey(variableId, index, argType))
+      .second;
+}
+
+bool TemplateProcessor::shouldInsertVariableTemplateArgumentValue(
+    int variableId, int index, int argValue) {
+  return variableTemplateArgumentValueDedup
+      .insert(makeTripleKey(variableId, index, argValue))
+      .second;
+}
+
+bool TemplateProcessor::shouldInsertTemplateTemplateInstantiation(int to,
+                                                                  int from) {
+  return templateTemplateInstantiationDedup.insert(makePairKey(to, from))
+      .second;
+}
+
+bool TemplateProcessor::shouldInsertTemplateTemplateArgument(int typeId,
+                                                             int index,
+                                                             int argType) {
+  return templateTemplateArgumentDedup
+      .insert(makeTripleKey(typeId, index, argType))
+      .second;
+}
+
+bool TemplateProcessor::shouldInsertConceptInstantiation(int conceptId,
+                                                         int templateId) {
+  return conceptInstantiationDedup.insert(makePairKey(conceptId, templateId))
+      .second;
+}
+
+bool TemplateProcessor::shouldInsertConceptTemplateArgument(int conceptId,
+                                                            int index,
+                                                            int argType) {
+  return conceptTemplateArgumentDedup
+      .insert(makeTripleKey(conceptId, index, argType))
+      .second;
+}
+
+bool TemplateProcessor::shouldInsertTypeTemplateTypeConstraint(
+    int typeId, int constraintId) {
+  return typeTemplateTypeConstraintDedup
+      .insert(makePairKey(typeId, constraintId))
+      .second;
+}
+
+bool TemplateProcessor::shouldInsertIsTypeConstraint(int conceptId) {
+  return isTypeConstraintDedup.insert(conceptId).second;
+}
+
+bool TemplateProcessor::shouldInsertNontypeTemplateParameter(int id) {
+  return nontypeTemplateParameterDedup.insert(id).second;
+}
+
+bool TemplateProcessor::shouldInsertConceptTemplateArgumentValue(
+    int conceptId, int index, int argValue) {
+  return conceptTemplateArgumentValueDedup
+      .insert(makeTripleKey(conceptId, index, argValue))
+      .second;
+}
+
+std::string
+TemplateProcessor::makeConceptTemplateKey(const clang::ConceptDecl *decl,
+                                          clang::ASTContext *context) {
+  if (!decl || !context)
+    return "";
+
+  const clang::ConceptDecl *canonicalDecl = decl->getCanonicalDecl();
+  return KeyGen::Type::makeKey(canonicalDecl, context);
+}
+
+int TemplateProcessor::resolveConceptTemplateId(
+    const clang::ConceptDecl *decl, clang::ASTContext *context) {
+  if (!decl || !context)
+    return -1;
+
+  const clang::ConceptDecl *canonicalDecl = decl->getCanonicalDecl();
+  std::string conceptKey = makeConceptTemplateKey(canonicalDecl, context);
+  if (conceptKey.empty())
+    return -1;
+
+  if (auto it = conceptTemplateIds.find(conceptKey);
+      it != conceptTemplateIds.end())
+    return it->second;
+
+  LocIdPair *locIdPair = SrcLocRecorder::processDefault(canonicalDecl, context);
+  DbModel::ConceptTemplate conceptTemplate = {
+      GENID(ConceptTemplate), canonicalDecl->getNameAsString(),
+      locIdPair->spec_id};
+
+  conceptTemplateIds.emplace(conceptKey, conceptTemplate.id);
+  STG.insertClassObj(conceptTemplate);
+  return conceptTemplate.id;
+}
+
+std::string TemplateProcessor::makeTemplateArgumentListKey(
+    llvm::ArrayRef<clang::TemplateArgument> args,
+    clang::ASTContext *context) {
+  std::string key;
+  llvm::raw_string_ostream os(key);
+  clang::PrintingPolicy policy(context->getLangOpts());
+
+  for (unsigned index = 0; index < args.size(); ++index) {
+    if (index != 0)
+      os << ",";
+    args[index].print(policy, os, true);
+  }
+
+  return os.str();
+}
+
+std::string TemplateProcessor::makeConceptSpecializationKey(
+    const clang::ConceptSpecializationExpr *expr,
+    clang::ASTContext *context) {
+  if (!expr || !context)
+    return "";
+
+  std::string conceptKey = makeConceptTemplateKey(expr->getNamedConcept(),
+                                                  context);
+  if (conceptKey.empty())
+    return "";
+
+  const clang::SourceManager &sourceManager = context->getSourceManager();
+  clang::SourceLocation beginLoc =
+      sourceManager.getSpellingLoc(expr->getBeginLoc());
+  clang::SourceLocation endLoc =
+      sourceManager.getSpellingLoc(expr->getEndLoc());
+
+  std::string locationKey;
+  if (beginLoc.isValid() && endLoc.isValid()) {
+    locationKey =
+        beginLoc.printToString(sourceManager) + "-" +
+        endLoc.printToString(sourceManager);
+  } else if (const auto *specializationDecl = expr->getSpecializationDecl()) {
+    locationKey = "implicit-decl-" + std::to_string(specializationDecl->getID());
+  } else {
+    locationKey =
+        "addr-" + std::to_string(reinterpret_cast<std::uintptr_t>(expr));
+  }
+
+  return conceptKey + "<" +
+         makeTemplateArgumentListKey(expr->getTemplateArguments(), context) +
+         ">@" + locationKey;
+}
+
+int TemplateProcessor::resolveConceptSpecializationId(
+    const clang::ConceptSpecializationExpr *expr,
+    clang::ASTContext *context) {
+  std::string specializationKey = makeConceptSpecializationKey(expr, context);
+  if (specializationKey.empty())
+    return -1;
+
+  if (auto it = conceptSpecializationIds.find(specializationKey);
+      it != conceptSpecializationIds.end())
+    return it->second;
+
+  int conceptId = IDGenerator::generateId<ConceptSpecializationId>();
+  conceptSpecializationIds.emplace(specializationKey, conceptId);
+  return conceptId;
+}

--- a/src/core/processor/template_processor.cc
+++ b/src/core/processor/template_processor.cc
@@ -4,11 +4,16 @@
 #endif
 
 #include "core/processor/template_processor.h"
+#include "core/processor/expr_processor.h"
+#include "core/processor/type_processor.h"
+#include "core/processor/variable_processor.h"
 #include "core/srcloc_recorder.h"
 #include "db/storage_facade.h"
 #include "model/db/concept.h"
 #include "util/id_generator.h"
+#include "util/key_generator/expr.h"
 #include "util/key_generator/type.h"
+#include "util/key_generator/variable.h"
 #include <clang/AST/ASTConcept.h>
 #include <clang/AST/DeclTemplate.h>
 #include <clang/AST/ExprConcepts.h>
@@ -249,4 +254,144 @@ int TemplateProcessor::resolveConceptSpecializationId(
   int conceptId = IDGenerator::generateId<ConceptSpecializationId>();
   conceptSpecializationIds.emplace(specializationKey, conceptId);
   return conceptId;
+}
+
+int TemplateProcessor::resolveVariableEntityId(const clang::VarDecl *decl) {
+  if (!decl || !variable_processor_ || !ast_context_)
+    return -1;
+
+  KeyType variableKey = KeyGen::Var::makeKey(decl, ast_context_);
+  if (auto cachedId = SEARCH_VARIABLE_CACHE(variableKey))
+    return *cachedId;
+
+  variable_processor_->processVarDecl(decl);
+  if (auto cachedId = SEARCH_VARIABLE_CACHE(variableKey))
+    return *cachedId;
+
+  return -1;
+}
+
+int TemplateProcessor::resolveTemplateArgumentTypeId(clang::QualType argType) {
+  if (argType.isNull() || !type_processor_ || !ast_context_)
+    return -1;
+
+  KeyType typeKey = KeyGen::Type::makeKey(argType, ast_context_);
+  if (auto cachedId = SEARCH_TYPE_CACHE(typeKey))
+    return *cachedId;
+
+  if (const auto *builtinType = argType->getAs<clang::BuiltinType>())
+    return type_processor_->processBuiltinType(builtinType, ast_context_);
+
+  if (const auto *recordType = argType->getAs<clang::RecordType>()) {
+    type_processor_->processRecordType(recordType);
+    if (auto cachedId = SEARCH_TYPE_CACHE(typeKey))
+      return *cachedId;
+  }
+
+  int typeId = type_processor_->processType(argType.getTypePtr());
+  if (typeId != -1)
+    return typeId;
+
+  if (auto cachedId = SEARCH_TYPE_CACHE(typeKey))
+    return *cachedId;
+
+  return -1;
+}
+
+int TemplateProcessor::resolveTemplateTemplateParmId(
+    const clang::TemplateTemplateParmDecl *decl) {
+  if (!decl || !type_processor_ || !ast_context_)
+    return -1;
+
+  KeyType typeKey = KeyGen::Type::makeKey(decl, ast_context_);
+  if (auto cachedId = SEARCH_TYPE_CACHE(typeKey))
+    return *cachedId;
+
+  int typeId = type_processor_->processTemplateTemplateParmDecl(decl);
+  if (typeId != -1)
+    return typeId;
+
+  if (auto cachedId = SEARCH_TYPE_CACHE(typeKey))
+    return *cachedId;
+
+  return -1;
+}
+
+int TemplateProcessor::resolveTemplateTemplateArgumentTypeId(
+    const clang::TemplateArgument &arg) {
+  if (arg.getKind() != clang::TemplateArgument::Template || !type_processor_ ||
+      !ast_context_)
+    return -1;
+
+  const clang::TemplateDecl *templateDecl =
+      arg.getAsTemplate().getAsTemplateDecl();
+  const auto *classTemplateDecl =
+      llvm::dyn_cast_or_null<clang::ClassTemplateDecl>(templateDecl);
+  if (!classTemplateDecl || !classTemplateDecl->getTemplatedDecl())
+    return -1;
+
+  const clang::CXXRecordDecl *templatedDecl =
+      classTemplateDecl->getTemplatedDecl();
+  KeyType templateTypeKey = KeyGen::Type::makeKey(templatedDecl, ast_context_);
+  if (auto cachedId = SEARCH_TYPE_CACHE(templateTypeKey))
+    return *cachedId;
+
+  int templateTypeId = type_processor_->processRecordDeclType(templatedDecl);
+  if (templateTypeId != -1)
+    return templateTypeId;
+
+  if (auto cachedId = SEARCH_TYPE_CACHE(templateTypeKey))
+    return *cachedId;
+
+  return -1;
+}
+
+const clang::Expr *TemplateProcessor::getTemplateArgumentSourceExpr(
+    const clang::TemplateArgumentLoc &argLoc) {
+  const clang::TemplateArgument &arg = argLoc.getArgument();
+
+  switch (arg.getKind()) {
+  case clang::TemplateArgument::Expression:
+    return argLoc.getSourceExpression();
+  case clang::TemplateArgument::Integral:
+    return argLoc.getSourceIntegralExpression();
+  default:
+    return nullptr;
+  }
+}
+
+int TemplateProcessor::resolveTemplateArgumentExprId(
+    const clang::Expr *sourceExpr) {
+  if (!sourceExpr || !expr_processor_ || !ast_context_)
+    return -1;
+
+  const clang::Expr *expr = sourceExpr->IgnoreParenImpCasts();
+  KeyType exprKey = KeyGen::Expr_::makeKey(expr, ast_context_);
+  if (auto cachedId = SEARCH_EXPR_CACHE(exprKey))
+    return *cachedId;
+
+  if (const auto *integerLiteral =
+          llvm::dyn_cast<clang::IntegerLiteral>(expr)) {
+    expr_processor_->processIntegerLiteral(integerLiteral);
+  } else if (const auto *floatingLiteral =
+                 llvm::dyn_cast<clang::FloatingLiteral>(expr)) {
+    expr_processor_->processFloatingLiteral(floatingLiteral);
+  } else if (const auto *characterLiteral =
+                 llvm::dyn_cast<clang::CharacterLiteral>(expr)) {
+    expr_processor_->processCharacterLiteral(characterLiteral);
+  } else if (const auto *boolLiteral =
+                 llvm::dyn_cast<clang::CXXBoolLiteralExpr>(expr)) {
+    expr_processor_->processBoolLiteral(boolLiteral);
+  } else if (const auto *declRefExpr =
+                 llvm::dyn_cast<clang::DeclRefExpr>(expr)) {
+    expr_processor_->processDeclRef(
+        const_cast<clang::DeclRefExpr *>(declRefExpr));
+  } else {
+    return -1;
+  }
+
+  if (auto cachedId = SEARCH_EXPR_CACHE(exprKey))
+    return *cachedId;
+
+  return -1;
 }


### PR DESCRIPTION
## 背景

此前由于路线图规划阶段的设计有问题，23 个模板相关表的处理逻辑被直接内联进 `ast_visitor.cc`，导致：

- Visitor 与 Processor 职责混杂
- 大量模板 dedup/cache/resolve/record/orchestration 聚集
- 匿名 namespace 超过 800 行
- 存在 process-global 模板静态状态

## 本次重构

新增 `TemplateProcessor`，渐进式迁移：

- dedup/cache 状态
- resolve* helper
- record* DB helper
- Visit* template orchestration

包括：

- class/function/variable template
- concept
- template-template
- type constraint

相关逻辑。

## 结果

- `ast_visitor.cc` 匿名 namespace 完全移除
- template logic 全部统一归属 `TemplateProcessor`
- Visit* 恢复 routing layer 职责
- 消除模板全局静态状态
- 不涉及 schema / ORM / datatable-list 变更

## 验证

已通过：

- `make debug -j 8`
- `scripts/test_all.sh`
- semantic DB baseline diff

`slight/moderate/intense` 三组测试的 semantic DB 全量一致。