### PR TITLE
建立 Arborchive 轻量化 Agent 工作流 infra（Trellis）

### DIFF
--- a/.agents/skills/arborchive-finish/SKILL.md
+++ b/.agents/skills/arborchive-finish/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: arborchive-finish
+description: "Finish an Arborchive task with a concise review-ready summary covering changed files, changes made, commands, verification result, risks, follow-ups, and commit message."
+---
+
+# Arborchive Finish
+
+Use this skill when the work is ready to summarize. It is a reporting skill,
+not an automation layer.
+
+## Final Summary Fields
+
+Include:
+
+- changed files;
+- what changed;
+- commands run;
+- verification result;
+- risks or known limitations;
+- follow-ups;
+- suggested commit message.
+
+For docs-only tasks, state that there is no runtime behavior change.
+
+For code or schema tasks, state which tests and database checks were run. If a
+command was not run, state why.
+
+## Boundaries
+
+- Do not auto commit.
+- Do not push.
+- Do not archive task directories.
+- Do not write personal journals.
+- Do not modify `.trellis/spec/` unless the user explicitly asks to preserve a
+  long-term rule.

--- a/.agents/skills/arborchive-orient/SKILL.md
+++ b/.agents/skills/arborchive-orient/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: arborchive-orient
+description: "Orient an agent at the start of an Arborchive task by loading governance docs, Trellis-style context docs, and the relevant Arborchive specs before planning or editing."
+---
+
+# Arborchive Orient
+
+Lightweight Arborchive-specific skill inspired by Trellis-style workflow. This
+is not Trellis runtime integration.
+
+## Required Reads
+
+Read these files before planning or editing:
+
+1. `AGENTS.md`
+2. `docs/agent_workflow.md`
+3. `.trellis/workflow.md`
+4. `.trellis/spec/README.md`
+5. Relevant `.trellis/spec/arborchive/*.md` files for the task
+
+## Classify The Task
+
+Classify the work before acting:
+
+- docs-only
+- roadmap or governance
+- AST visitor boundary
+- processor or semantic extraction
+- schema or CodeQL alignment
+- test or verification
+
+## Output
+
+Before implementation, state:
+
+- task type;
+- allowed files and directories;
+- forbidden files and directories;
+- specs read;
+- remaining context still needed.
+
+## Boundaries
+
+- Do not edit code from this skill.
+- Do not create generated task state.
+- Do not rely on generated command layers.

--- a/.agents/skills/arborchive-plan/SKILL.md
+++ b/.agents/skills/arborchive-plan/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: arborchive-plan
+description: "Create a lightweight Arborchive implementation plan with scope, non-goals, allowed paths, forbidden paths, required specs, validation plan, and risks before editing."
+---
+
+# Arborchive Plan
+
+Use this skill before implementation when the task needs a clear boundary. It
+is a lightweight Arborchive-specific planning aid, not Trellis runtime
+integration.
+
+## Plan Fields
+
+Write a concise plan that covers:
+
+- task goal;
+- scope;
+- non-goals;
+- allowed files or directories;
+- forbidden files or directories;
+- required specs;
+- validation plan;
+- expected risks.
+
+## Optional Task Notes
+
+For complex tasks, suggest a generic task context directory:
+
+```text
+.trellis/tasks/<task-slug>/
+  prd.md
+  research.md
+  validation.md
+  summary.md
+```
+
+These files are reusable task context for review. They are not personal
+session state and should not store developer identity, local state, or active
+session data.
+
+## Boundaries
+
+- Do not create personal onboarding task directories.
+- Do not write developer or session state.
+- Do not auto commit.
+- Do not expand the task beyond the stated subsystem.

--- a/.agents/skills/arborchive-schema-review/SKILL.md
+++ b/.agents/skills/arborchive-schema-review/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: arborchive-schema-review
+description: "Review Arborchive schema and CodeQL alignment changes for table category, counterpart semantics, extension rationale, validation query, migration impact, and tests."
+---
+
+# Arborchive Schema Review
+
+Use this skill for schema, ORM, database model, or CodeQL alignment review.
+
+## Required Reads
+
+Read:
+
+- `.trellis/spec/arborchive/schema-codeql-alignment.md`
+- `.trellis/spec/arborchive/architecture.md`
+- `.trellis/spec/arborchive/testing-and-verification.md`
+
+## Review Checklist
+
+For every schema change, check:
+
+- CodeQL counterpart;
+- Arbor-specific reason;
+- table category: CodeQL-aligned, Arbor extension, or experimental-deferred;
+- validation query;
+- alignment risk;
+- migration impact;
+- affected tests or fixtures.
+
+Also check:
+
+- no undocumented table was added;
+- Arbor extension names use `arbor_*` or have clear documentation;
+- CodeQL-aligned semantics were not polluted by convenience-only design;
+- deferred or experimental ideas did not enter production schema silently.
+
+## Boundaries
+
+- Do not suggest a new table only because implementation would be easier.
+- Do not mix unrelated roadmap phases into schema work.
+- Require database evidence for schema or semantic output changes.

--- a/.agents/skills/arborchive-verify/SKILL.md
+++ b/.agents/skills/arborchive-verify/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: arborchive-verify
+description: "Verify Arborchive changes using the project verification spec, choosing docs-only, behavior, schema, database, and build checks based on the change type."
+---
+
+# Arborchive Verify
+
+Use this skill after changes and before final reporting. Follow
+`.trellis/spec/arborchive/testing-and-verification.md`.
+
+## Docs-Only Changes
+
+Run:
+
+```bash
+git diff --check
+git status --short
+git diff --name-only
+```
+
+Explain why behavior tests are not required when no code, schema, build, or
+fixture files changed.
+
+## Behavior, Processor, Or Schema Changes
+
+Run the relevant checks:
+
+```bash
+scripts/test_all.sh
+```
+
+When semantic output changes, inspect generated database output as needed:
+
+```bash
+python3 scripts/db_summary.py tests/output/<case>.db
+sqlite3 tests/output/<case>.db ".tables"
+sqlite3 tests/output/<case>.db "select * from <table> limit 10;"
+```
+
+For schema or ORM changes, consider the full path:
+
+```bash
+python3 scripts/generate_instantiations.py
+make debug -j 8
+scripts/test_all.sh
+```
+
+## Report
+
+Always report:
+
+- commands run;
+- exit result;
+- database files inspected;
+- tables checked;
+- commands not run, with reasons;
+- remaining risk.
+
+Do not claim completion when required checks fail or could not run.

--- a/.trellis/spec/README.md
+++ b/.trellis/spec/README.md
@@ -1,0 +1,49 @@
+# Trellis Spec Layer
+
+`.trellis/spec/` is the long-term rule layer for AI agents working on
+Arborchive. It stores stable engineering constraints, architecture boundaries,
+historical failure notes, and validation protocols.
+
+It is not a task log. Temporary task summaries, scratch plans, or one-off
+handoff notes belong in `.trellis/tasks/` or `.trellis/workspace/`.
+
+## Governance Position
+
+- `AGENTS.md` is the top-level constitution and total rule source.
+- `AGENT_WORKFLOW.md` is the execution protocol. In this checkout, the file is
+  currently stored as `docs/agent_workflow.md`.
+- `AGENTS_GUIDE.md` is legacy reference material and has the lowest
+  documentation priority.
+- `.trellis/spec/` contains reusable long-term engineering rules for agents.
+- `.trellis/tasks/` contains context for a single task.
+- `.trellis/workspace/` contains session notes and reusable memory.
+- `docs/` remains the place for human-readable roadmaps, phase summaries, and
+  long-form analysis.
+
+`.trellis/` complements `docs/`; it does not replace it.
+
+## Arborchive Spec Index
+
+- `arborchive/architecture.md`: high-level extraction architecture and
+  persistent fact model.
+- `arborchive/ast-visitor-boundary.md`: hard boundary for keeping
+  `ASTVisitor` thin.
+- `arborchive/processor-boundary.md`: processor ownership and semantic domain
+  guidance.
+- `arborchive/schema-codeql-alignment.md`: schema categories, CodeQL alignment,
+  and extension rules.
+- `arborchive/testing-and-verification.md`: validation commands and evidence
+  expectations.
+- `arborchive/commit-and-pr-style.md`: commit, PR, and review reporting style.
+
+## Agent Usage
+
+Before complex tasks, agents must read the specs relevant to the requested
+subsystem. Schema tasks must read `schema-codeql-alignment.md`. Visitor or
+processor tasks must read `ast-visitor-boundary.md` and
+`processor-boundary.md`. Behavior-changing tasks must read
+`testing-and-verification.md`.
+
+Specs should record stable rules, architecture boundaries, historical mistakes,
+and verification protocols. Do not put short-lived task conclusions here unless
+they have become durable governance.

--- a/.trellis/spec/arborchive/architecture.md
+++ b/.trellis/spec/arborchive/architecture.md
@@ -1,0 +1,62 @@
+# Arborchive Architecture
+
+Arborchive extracts C++ semantic facts from source code into a SQLite database
+with CodeQL-compatible analysis as a major design constraint.
+
+The intended flow is:
+
+```text
+source code
+  -> Clang AST
+  -> ASTVisitor traversal
+  -> domain processors
+  -> DB models
+  -> SQLite output
+  -> CodeQL-compatible analysis layer
+```
+
+## Layer Responsibilities
+
+- `ASTVisitor` is traversal orchestration only.
+- Processors own semantic extraction.
+- DB models represent persisted facts.
+- SQLite output is the reviewable artifact for extracted facts.
+- CodeQL compatibility constrains naming, table semantics, and schema shape.
+
+`ASTVisitor` may identify AST entrypoints and delegate work. It should not own
+semantic pipelines, schema row assembly, or subsystem-specific extraction
+policy.
+
+Processors and helpers should own domain logic such as template semantics, type
+extraction, namespace ownership, lambda capture extraction, inheritance/layout
+facts, attributes, initialization, statements, and expressions.
+
+## Schema Discipline
+
+Schema changes must be documented and tied to a semantic subsystem. A schema
+patch should explain:
+
+- what CodeQL concept it aligns with;
+- whether the table is a CodeQL counterpart, Arbor extension, or deferred
+  experiment;
+- which DB models, table definitions, and storage paths changed;
+- how the output was validated.
+
+Do not add tables only because they are convenient for an implementation path.
+Do not silently break CodeQL compatibility.
+
+## Verification Discipline
+
+Behavior or schema changes require tests and SQLite validation. At minimum,
+agents should run the relevant test suite and inspect the generated database
+when extraction output changes.
+
+Use targeted tests and SQL queries to show that representative rows exist and
+that table semantics match the intended subsystem.
+
+## Architectural Reminder
+
+Do not optimize for quick patches at the cost of architecture boundaries. A
+small patch that preserves ownership is better than a fast patch that turns
+traversal, extraction, schema mapping, and storage policy into one tangled
+change.

--- a/.trellis/spec/arborchive/ast-visitor-boundary.md
+++ b/.trellis/spec/arborchive/ast-visitor-boundary.md
@@ -1,0 +1,57 @@
+# ASTVisitor Boundary
+
+`src/core/ast_visitor.cc` is a hard architecture boundary. The file should stay
+as close as possible to a dispatch-only traversal layer.
+
+## ASTVisitor May
+
+- Visit Clang AST nodes.
+- Preserve traversal order.
+- Perform lightweight guards needed for traversal safety.
+- Delegate to processors or helpers.
+- Pass AST nodes and context information to processors.
+- Keep `Visit*` functions thin and predictable.
+
+## ASTVisitor Must Not
+
+- Implement complex semantic extraction.
+- Directly construct large business records.
+- Directly insert database rows.
+- Own template, type, layout, lambda, attribute, initialization, statement, or
+  expression extraction details.
+- Own CodeQL schema mapping decisions.
+- Accumulate cache, key, dependency, or storage policy.
+- Become a dumping ground for roadmap features.
+
+## Preferred Shape
+
+```cpp
+bool ASTVisitor::VisitFooDecl(clang::FooDecl *D) {
+  if (!D) return true;
+  foo_processor_->processFooDecl(D);
+  return true;
+}
+```
+
+Short compatibility glue may exist in transitional legacy areas, but new work
+should not expand that pattern. If a `Visit*` method needs repeated branching,
+cross-table coordination, or schema-specific decisions, move the logic into an
+owned processor or helper first.
+
+## Historical Note
+
+A previous roadmap mistake caused too much template-table logic to be placed
+inside `ast_visitor.cc`. The project later refactored this logic back into
+processors. Future agent work must treat ASTVisitor thinness as a hard
+architectural boundary.
+
+## Drift Signals
+
+Stop and review ownership if:
+
+- a new `Visit*` method calls multiple processors without a documented
+  compatibility reason;
+- visitor code assembles schema rows;
+- visitor code directly uses database storage APIs;
+- visitor code grows cache, key, or dependency policy;
+- a roadmap feature is easier to add by placing subsystem logic in traversal.

--- a/.trellis/spec/arborchive/commit-and-pr-style.md
+++ b/.trellis/spec/arborchive/commit-and-pr-style.md
@@ -1,0 +1,46 @@
+# Commit and PR Style
+
+Arborchive patches should be small, reviewable, and easy to roll back.
+
+## Commits
+
+- Keep commits focused on one semantic subsystem or one documentation boundary.
+- Prefer clear engineering intent over noisy file-by-file descriptions.
+- Use the repository's existing commit style when practical.
+- Do not include generated lockfiles or dependency artifacts unless the task
+  explicitly requires them.
+- Do not mix architecture cleanup with unrelated feature work.
+
+Good commit messages explain the outcome:
+
+```text
+docs: add trellis-style agent context layer
+```
+
+## Pull Requests
+
+PR descriptions should include:
+
+- Summary.
+- Motivation.
+- Changes.
+- Validation.
+- Risks or known limitations.
+- Follow-ups, if any.
+
+For schema or semantic extraction PRs, include the CodeQL alignment statement,
+affected tables, and representative validation queries.
+
+For docs-only PRs, state that no behavior or schema files changed and list the
+documentation validation performed.
+
+## Review Boundaries
+
+Each PR should make it obvious:
+
+- which files were allowed to change;
+- which files were intentionally not changed;
+- which architecture boundary is being preserved;
+- which command output proves the patch is ready for review.
+
+If the patch cannot be reviewed independently, split it before opening the PR.

--- a/.trellis/spec/arborchive/processor-boundary.md
+++ b/.trellis/spec/arborchive/processor-boundary.md
@@ -1,0 +1,58 @@
+# Processor Boundary
+
+Processors are the owners of semantic extraction in Arborchive.
+
+`ASTVisitor` should discover AST entrypoints and delegate. Processors and their
+helpers should own the meaning, normalization, validation assumptions, and
+database-facing facts for their semantic domain.
+
+## Processor Responsibilities
+
+- Own semantic extraction for the corresponding domain.
+- Provide explicit orchestration APIs for new `Visit*` logic to call.
+- Keep APIs testable and reviewable.
+- Reuse existing key, location, cache, and storage conventions.
+- Document cross-domain writes when they are necessary.
+- Avoid hidden coupling between unrelated roadmap phases.
+- Include validation queries or targeted tests for large new extraction
+  behavior.
+
+## Domain Guidance
+
+Common semantic domains include:
+
+- template processor behavior;
+- type processor behavior;
+- namespace processor behavior;
+- lambda processor behavior;
+- inheritance and layout processor/helper behavior;
+- function, variable, statement, and expression processor behavior when
+  applicable;
+- attribute and initialization processor/helper behavior when applicable.
+
+This list describes ownership domains, not a requirement to invent class names.
+If a concrete processor does not exist yet, establish the boundary in a helper
+or dominant subsystem owner before adding extraction logic.
+
+## Cross-Domain Writes
+
+Processors should avoid writing facts owned by another domain unless the
+relationship is documented and verified. When cross-domain writes are necessary,
+the patch should explain:
+
+- why the current domain is the right owner;
+- which table or model is affected;
+- how the relationship aligns with CodeQL semantics;
+- which validation query or test proves the behavior.
+
+## API Shape
+
+Processor APIs should make intent clear:
+
+- pass Clang AST objects and context needed for extraction;
+- return stable IDs or status only when callers need them;
+- hide schema row construction inside the owning layer;
+- keep unsupported or deferred semantics explicit.
+
+Large extraction work should come with targeted fixtures or SQL evidence, not
+only a successful build.

--- a/.trellis/spec/arborchive/schema-codeql-alignment.md
+++ b/.trellis/spec/arborchive/schema-codeql-alignment.md
@@ -1,0 +1,73 @@
+# Schema and CodeQL Alignment
+
+Arborchive schema work must preserve CodeQL compatibility as a first-class
+constraint. Schema changes are semantic design work, not bookkeeping.
+
+## Schema Change Categories
+
+### 1. CodeQL-Aligned Tables
+
+Use this category when the table is intended to correspond to a CodeQL C/C++
+database concept.
+
+- Preserve CodeQL naming and semantics where possible.
+- Document the corresponding CodeQL concept.
+- Keep column meanings aligned with `docs/semmlecode.cpp.dbscheme`.
+- Validate representative rows against the intended CodeQL behavior.
+
+### 2. Arbor Extension Tables
+
+Use this category when Arborchive needs facts that do not have a direct CodeQL
+counterpart.
+
+- Use an `arbor_*` prefix or explicitly documented extension naming.
+- Explain why CodeQL has no direct counterpart.
+- Explain how the extension helps Arborchive without breaking CodeQL
+  alignment.
+- Make the extension boundary clear so future agents do not mistake it for a
+  CodeQL table.
+
+If a table is a reinforcement or extension rather than a CodeQL counterpart,
+document it clearly. If naming may confuse CodeQL alignment, prefer explicit
+`arbor_*` naming or equally explicit documentation.
+
+### 3. Experimental or Deferred Tables
+
+Use this category for planned or researched schema ideas that should not enter
+the production schema yet.
+
+- Record the decision in the roadmap or analysis docs.
+- Do not silently add experimental tables to production schema.
+- Explain why implementation is deferred.
+- Record the condition that would make the table ready for implementation.
+
+## Required Schema Change Explanation
+
+Every schema change must state:
+
+- CodeQL counterpart.
+- Arbor-specific reason.
+- Validation query.
+- Alignment risk.
+- Migration impact.
+- Affected tests or fixtures.
+
+## Hard Rules
+
+- Do not silently break CodeQL compatibility.
+- Do not add tables only because they are convenient.
+- Do not use undocumented names that look CodeQL-aligned when they are Arbor
+  extensions.
+- Do not mix unrelated roadmap phases into a schema patch.
+- Do not skip ORM regeneration when ORM/schema files change.
+
+## Review Checklist
+
+Before merging schema work, reviewers should be able to answer:
+
+- Is this table listed in `docs/datatable-list.txt` or explicitly documented as
+  an approved Arbor extension?
+- Does the patch explain the CodeQL counterpart or lack of counterpart?
+- Are model, table definition, initialization, and storage paths synchronized?
+- Did the agent run generation and validation commands?
+- Are SQL queries or DB summaries included for changed semantic output?

--- a/.trellis/spec/arborchive/testing-and-verification.md
+++ b/.trellis/spec/arborchive/testing-and-verification.md
@@ -1,0 +1,78 @@
+# Testing and Verification
+
+Verification is required for Arborchive patches. A task is not complete until
+the agent reports what was run, what passed, what could not run, and what risk
+remains.
+
+## Common Commands
+
+Run the full test entrypoint for normal code or schema patches:
+
+```bash
+scripts/test_all.sh
+```
+
+Inspect a generated database summary when semantic extraction changes:
+
+```bash
+python3 scripts/db_summary.py tests/output/<case>.db
+```
+
+List generated tables:
+
+```bash
+sqlite3 tests/output/<case>.db ".tables"
+```
+
+Inspect representative rows:
+
+```bash
+sqlite3 tests/output/<case>.db "select * from <table> limit 10;"
+```
+
+For schema/ORM changes, regenerate and rebuild before running tests:
+
+```bash
+python3 scripts/generate_instantiations.py
+make debug -j 8
+scripts/test_all.sh
+```
+
+## Validation by Patch Type
+
+Docs-only changes:
+
+- Validate that links and paths are accurate.
+- Confirm the diff touches only allowed documentation paths.
+- Report that behavior tests were not required when no code/schema changed.
+
+C++ behavior changes:
+
+- Run `scripts/test_all.sh`.
+- Add or update targeted fixtures when the behavior is not covered.
+- Use SQLite checks when output facts change.
+
+Schema or ORM changes:
+
+- Regenerate ORM instantiations.
+- Build the debug target.
+- Run the full test suite.
+- Inspect `.tables`, row counts, and representative rows for affected tables.
+
+Roadmap or governance changes:
+
+- Check consistency with `AGENTS.md`, `docs/agent_workflow.md`, and
+  `docs/roadmap.md`.
+- Ensure `.trellis/` does not contradict or replace `docs/`.
+
+## Reporting Format
+
+Final summaries should include:
+
+- changed files;
+- validation commands;
+- command results;
+- unrun commands with reasons;
+- remaining risks.
+
+Never claim a task is fully verified if required commands could not run.

--- a/.trellis/tasks/README.md
+++ b/.trellis/tasks/README.md
@@ -1,0 +1,30 @@
+# Trellis Tasks
+
+`.trellis/tasks/` stores task-specific context for a single work item.
+
+Use this directory for:
+
+- research notes for an active task;
+- PRDs or implementation checklists;
+- validation plans;
+- temporary handoff notes;
+- task-specific SQL snippets or review evidence summaries.
+
+Do not use this directory for stable architecture rules. Durable rules belong
+in `.trellis/spec/`. Human-readable roadmap or phase analysis belongs in
+`docs/`.
+
+Task notes should be scoped, dated when useful, and removable after they are
+captured in a PR, roadmap note, or long-term spec.
+
+Suggested structure:
+
+```text
+.trellis/tasks/<task-slug>/
+  plan.md
+  research.md
+  validation.md
+```
+
+For small tasks, a dedicated subdirectory is optional. Avoid turning task notes
+into a second documentation tree.

--- a/.trellis/tasks/examples/README.md
+++ b/.trellis/tasks/examples/README.md
@@ -1,0 +1,79 @@
+# Task Examples
+
+This directory is for commit-safe, non-personal examples that show future
+agents how to organize task context in Arborchive.
+
+Examples here are templates. They are not runtime task state, personal
+onboarding tasks, active session records, or Trellis CLI output. Do not include
+usernames, local machine paths, tokens, private keys, API keys, session IDs, or
+current-task status.
+
+## What Belongs Here
+
+Use examples to document the shape of a task directory that can be copied or
+adapted by Codex, Claude, Antigravity, or another agent without depending on a
+specific agent platform.
+
+Recommended structure:
+
+```text
+.trellis/tasks/examples/<task-kind>/
+  prd.md
+  research.md
+  validation.md
+  summary.md
+```
+
+Small tasks can keep these sections in one file, but larger tasks should split
+them so the task boundary, investigation, checks, and handoff remain easy to
+review.
+
+## File Roles
+
+`prd.md` should describe the task goal, scope, non-goals, allowed files,
+forbidden files, acceptance criteria, and validation plan. It should make the
+task boundary clear before implementation starts.
+
+`research.md` should record relevant codebase findings, architecture notes,
+open questions, alternatives considered, and decisions. It should cite local
+files or docs when useful, but it should not become a long-term rule document.
+
+`validation.md` should list the commands, database checks, documentation
+checks, or manual review steps that prove the task is complete. It should also
+record skipped checks with reasons.
+
+`summary.md` should capture the final review handoff: changed files, commands
+run, verification result, risks, known limitations, and follow-ups.
+
+## Governance Boundaries
+
+Keep the context layers separate:
+
+- `.trellis/spec/` stores stable long-term engineering rules, architecture
+  boundaries, and verification protocols.
+- `.trellis/tasks/` stores context for a single task.
+- `.trellis/workspace/` stores session notes and reusable memory that may help
+  future sessions but is not formal project governance.
+- `docs/` remains the home for human-readable roadmaps, phase summaries, and
+  long-form analysis documents.
+
+If a task note becomes a stable rule, promote it into `.trellis/spec/` or
+`docs/` as appropriate. If it is temporary session memory, keep it in
+`.trellis/workspace/`.
+
+## What Must Not Be Committed
+
+Do not commit personal onboarding or runtime task directories, such as
+developer-specific join tasks or active-session scratch directories.
+
+Do not commit content containing:
+
+- personal usernames or developer IDs;
+- local absolute paths;
+- tokens, passwords, API keys, private keys, or credentials;
+- active session state;
+- generated Trellis CLI runtime files;
+- assumptions that require Trellis CLI hooks or `.trellis/scripts/`.
+
+Examples should be plain Markdown and should work as guidance even when an
+agent only reads the repository files directly.

--- a/.trellis/workflow.md
+++ b/.trellis/workflow.md
@@ -1,0 +1,98 @@
+# Trellis-Style Agent Workflow
+
+This file defines the Arborchive agent workflow layer inspired by Trellis-style
+workflow/spec/tasks/workspace separation.
+
+It does not introduce a Trellis runtime dependency, copy Trellis source code, or
+replace the existing `docs/` hierarchy.
+
+## Governance Map
+
+- `AGENTS.md` is the top-level constitution and architectural rule source.
+- `AGENT_WORKFLOW.md` is the execution protocol. In this checkout, the file is
+  currently stored as `docs/agent_workflow.md`.
+- `AGENTS_GUIDE.md` is legacy reference material and has the lowest
+  documentation priority.
+- `.trellis/spec/` stores reusable long-term engineering rules for agents.
+- `.trellis/tasks/` stores task-specific context for a single work item.
+- `.trellis/workspace/` stores session notes and reusable memory.
+- `docs/` remains the place for human-readable roadmaps, phase summaries, and
+  long-form analysis.
+
+`.trellis/` is an agent context layer. It must not replace `docs/`.
+
+## Phase 1: Orient
+
+Before acting, load the governance and task context in this order:
+
+1. Read `AGENTS.md`.
+2. Read `AGENT_WORKFLOW.md` (`docs/agent_workflow.md` in this checkout).
+3. Read `.trellis/spec/README.md`.
+4. Read the relevant `.trellis/spec/arborchive/*.md` files for the task.
+5. Read task-specific notes under `.trellis/tasks/` when present.
+6. Read reusable notes under `.trellis/workspace/` when they are relevant.
+
+For C++ behavior or schema work, also load the current roadmap, AST dispatch
+flow, related processor ownership, and related model/table files before making
+changes.
+
+## Phase 2: Plan
+
+Do not begin by editing when the task boundary is unclear.
+
+- Write or update research notes first when the requested scope is ambiguous.
+- For complex work, produce a PRD, checklist, or validation plan before
+  implementation.
+- Identify the semantic subsystem that owns the change.
+- Explicitly list files or directories that are allowed to change.
+- Explicitly list files or directories that are forbidden to change.
+- Decide which verification commands and database checks will prove the change.
+
+Planning is part of the work. A patch that cannot be isolated to a clear
+subsystem should be split or researched further.
+
+## Phase 3: Implement
+
+Make only the changes that fit the task boundary.
+
+- Keep patches small, reversible, and reviewable.
+- Keep `ASTVisitor` thin and dispatch-oriented.
+- Put semantic extraction logic in the corresponding processor or helper layer.
+- Use explicit processor APIs instead of expanding `Visit*` orchestration.
+- Keep roadmap phases isolated.
+- If schema changes are required, document the CodeQL alignment relationship.
+- Do not add tables merely because they are convenient.
+
+Implementation should preserve architecture boundaries even when a local quick
+patch looks faster.
+
+## Phase 4: Verify
+
+Verification is mandatory. A task without Verify is incomplete.
+
+Choose validation based on the patch type:
+
+- Run tests that cover the modified behavior.
+- Run `scripts/test_all.sh` for normal code or schema patches.
+- Run `python3 scripts/db_summary.py tests/output/<case>.db` when semantic
+  output changes.
+- Run SQLite table and sample-row queries for schema or extraction changes.
+- Regenerate ORM instantiations before validation when schema/ORM files change.
+- For docs-only changes, validate the changed links, paths, hierarchy claims,
+  and git diff scope.
+
+If a command cannot be run, state the exact reason and the residual risk.
+Do not silently skip verification.
+
+## Phase 5: Summarize
+
+Every final task summary must include:
+
+- Changed files.
+- Commands run.
+- Verification result.
+- Risks or known limitations.
+- Follow-ups, if any.
+
+The summary should make review easy: explain what changed, how it was checked,
+and what remains uncertain.

--- a/.trellis/workspace/README.md
+++ b/.trellis/workspace/README.md
@@ -1,0 +1,18 @@
+# Trellis Workspace
+
+`.trellis/workspace/` stores session notes and reusable agent memory for
+Arborchive.
+
+Use this directory for:
+
+- recurring local workflow notes;
+- reusable investigation summaries;
+- environment observations that help future sessions;
+- non-sensitive reminders about validation, tooling, or review habits.
+
+Do not store secrets, tokens, private credentials, or machine-specific paths
+that are not useful to other maintainers.
+
+Workspace notes are lower priority than `AGENTS.md`, `docs/agent_workflow.md`,
+`.trellis/spec/`, and `docs/roadmap.md`. If a workspace note becomes a stable
+rule, promote it into `.trellis/spec/` or `docs/` as appropriate.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,14 +11,34 @@ It is not a general development note or onboarding tutorial.
 
 Priority order:
 
-text AGENTS.md ↓ docs/AGENT_WORKFLOW.md ↓ docs/roadmap.md ↓ existing code patterns
+```text
+AGENTS.md
+↓ docs/AGENT_WORKFLOW.md
+↓ .trellis/workflow.md
+↓ .trellis/spec/
+↓ docs/roadmap.md
+↓ existing code patterns
+```
 
-Canonical workflow file: `docs/AGENT_WORKFLOW.md`.
-Legacy/onboarding encyclopedia: `docs/AGENTS_GUIDE.md`.
+`AGENTS.md` is the top-level constitution / total rule source.
+`docs/AGENT_WORKFLOW.md` is the execution protocol. In this checkout, the file
+is currently stored as `docs/agent_workflow.md`.
+`docs/AGENTS_GUIDE.md` is legacy reference material and has the lowest
+documentation priority.
+
+`.trellis/` is an agent context layer, not a replacement for `docs/`:
+
+- `.trellis/spec/` stores reusable long-term engineering rules for agents.
+- `.trellis/tasks/` stores context for a single task.
+- `.trellis/workspace/` stores session notes and reusable memory.
+- `docs/` remains for human-readable roadmaps, phase summaries, and long-form
+  analysis.
 
 If existing code conflicts with this document:
 
-text AGENTS.md wins.
+```text
+AGENTS.md wins.
+```
 
 If `docs/AGENTS_GUIDE.md` conflicts with this document, `AGENTS.md` wins.
 
@@ -237,7 +257,10 @@ Before modifying C++ behavior, agents MUST understand:
 Minimum required files:
 
 - AGENTS.md
-- docs/AGENT_WORKFLOW.md
+- docs/AGENT_WORKFLOW.md (`docs/agent_workflow.md` in this checkout)
+- .trellis/workflow.md
+- .trellis/spec/README.md
+- relevant .trellis/spec/arborchive/*.md files for the task
 - docs/roadmap.md
 - src/core/ast_visitor.cc
 - related processor/model/table files

--- a/docs/agent_workflow.md
+++ b/docs/agent_workflow.md
@@ -12,6 +12,21 @@ AGENTS.md wins.
 This document defines execution flow, implementation discipline, and validation
 protocol. It does not redefine architecture ownership.
 
+## Trellis-Style Context Layer
+
+Arborchive also maintains `.trellis/` as an agent context layer:
+
+- `.trellis/workflow.md` summarizes the Orient, Plan, Implement, Verify, and
+  Summarize workflow for agents.
+- `.trellis/spec/` stores reusable long-term engineering rules.
+- `.trellis/tasks/` stores context for individual tasks.
+- `.trellis/workspace/` stores session notes and reusable memory.
+- `docs/` remains the home for human-readable roadmaps, phase summaries, and
+  long-form analysis.
+
+This layer complements `AGENTS.md` and this execution protocol. It does not
+replace `docs/`, `docs/roadmap.md`, or `docs/AGENTS_GUIDE.md`.
+
 ---
 
 # Phase 1 — Context Loading
@@ -27,9 +42,17 @@ Before modifying C++ behavior, agents MUST understand:
 Minimum required context:
 
 - `AGENTS.md`
+- `docs/AGENT_WORKFLOW.md` (`docs/agent_workflow.md` in this checkout)
+- `.trellis/workflow.md`
+- `.trellis/spec/README.md`
+- relevant `.trellis/spec/arborchive/*.md` files for the task
 - `docs/roadmap.md`
 - `src/core/ast_visitor.cc`
 - related processor/model/table files
+
+For complex tasks, agents MUST read `.trellis/workflow.md` before planning and
+the relevant `.trellis/spec/arborchive/*.md` files before implementation or
+verification.
 
 If schema/ORM changes are involved, also review:
 


### PR DESCRIPTION
## 概要

本 PR 为 Arborchive引入了轻量 Agent 治理层，是一个基于 Trellis 的 spec / task / workflow / skills 思想，为后续 AI-assisted development 提供明确的上下文、架构边界和验证协议。

## 改动

- 新增 `.trellis/workflow.md`，定义 Arborchive agent 工作流。
- 新增 `.trellis/spec/arborchive/*`，沉淀 ASTVisitor、processor、schema/CodeQL 对齐、测试验证等长期规则。
- 新增 `.trellis/tasks/examples/README.md`，提供非个人化 task 上下文示例。
- 新增 `.agents/skills/arborchive-*` 轻量 skills：
  - `arborchive-orient`
  - `arborchive-plan`
  - `arborchive-verify`
  - `arborchive-schema-review`
  - `arborchive-finish`

## 范围

本 PR 暂不启用 Trellis runtime，不提交 `.codex/`、hooks、`.trellis/scripts/`、template hashes、官方 `trellis-*` skills 或个人 task 状态。

当前方案是 Arborchive 自定义的 lightweight skills + 文档治理层。

未来通过P7验证接下来的工作流能力后考虑启用runtime。

## 验证

- `git diff --check` passed
- 未修改业务代码
- 未修改 `src/`、`include/`、`tests/`、`scripts/`、`CMakeLists.txt`
- 未新增 runtime hooks / scripts / personal task state

## 风险

- 当前 skills 尚未在完整真实任务中验证。
- 后续需要在独立 P7 pilot 分支中测试该 workflow 对 schema / processor 任务的约束效果。